### PR TITLE
feat: add preferred node affinities

### DIFF
--- a/internal/strategy/lbsvc.go
+++ b/internal/strategy/lbsvc.go
@@ -89,6 +89,7 @@ func installOnSource(attempt *migration.Attempt, releaseName, publicKey, srcMoun
 					"mountPath": srcMountPath,
 				},
 			},
+			"affinity": sourceInfo.AffinityHelmValues,
 		},
 	}
 
@@ -132,7 +133,8 @@ func installOnDest(attempt *migration.Attempt, releaseName, privateKey,
 					"mountPath": destMountPath,
 				},
 			},
-			"command": rsyncCmdStr,
+			"command":  rsyncCmdStr,
+			"affinity": destInfo.AffinityHelmValues,
 		},
 	}
 

--- a/internal/strategy/local.go
+++ b/internal/strategy/local.go
@@ -197,6 +197,7 @@ func installLocalOnSource(attempt *migration.Attempt, releaseName,
 					"mountPath": srcMountPath,
 				},
 			},
+			"affinity": sourceInfo.AffinityHelmValues,
 		},
 	}
 
@@ -219,6 +220,7 @@ func installLocalOnDest(attempt *migration.Attempt, releaseName, publicKey, dest
 					"mountPath": destMountPath,
 				},
 			},
+			"affinity": destInfo.AffinityHelmValues,
 		},
 	}
 

--- a/internal/strategy/mnt2.go
+++ b/internal/strategy/mnt2.go
@@ -60,7 +60,8 @@ func (r *Mnt2) Run(attempt *migration.Attempt) (bool, error) {
 					"mountPath": destMountPath,
 				},
 			},
-			"command": rsyncCmd,
+			"command":  rsyncCmd,
+			"affinity": sourceInfo.AffinityHelmValues,
 		},
 	}
 

--- a/internal/strategy/svc.go
+++ b/internal/strategy/svc.go
@@ -98,7 +98,8 @@ func buildHelmVals(mig *migration.Migration, helmReleaseName string) (map[string
 					"mountPath": destMountPath,
 				},
 			},
-			"command": rsyncCmdStr,
+			"command":  rsyncCmdStr,
+			"affinity": destInfo.AffinityHelmValues,
 		},
 		"sshd": map[string]any{
 			"enabled":   true,
@@ -111,6 +112,7 @@ func buildHelmVals(mig *migration.Migration, helmReleaseName string) (map[string
 					"readOnly":  mig.Request.SourceMountReadOnly,
 				},
 			},
+			"affinity": sourceInfo.AffinityHelmValues,
 		},
 	}, nil
 }


### PR DESCRIPTION
Schedules the pod on the same node that it is mounted on (if it is mounted at all). 
Works on a best-effort basis.

Closes #180 

