### PR TITLE
feat: add flag --source-dns-suffix

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -47,6 +47,7 @@ Flags:
   -o, --no-chown                       omit chown on rsync
   -b, --no-progress-bar                do not display a progress bar
   -c, --source-context string          context in the kubeconfig file of the source PVC
+  -S  --source-dns-suffix              dns suffix for destination cluster (for inter-cluster services)
   -k, --source-kubeconfig string       path of the kubeconfig file of the source PVC
   -R, --source-mount-read-only         mount the source PVC in ReadOnly mode (default true)
   -n, --source-namespace string        namespace of the source PVC
@@ -132,4 +133,3 @@ $ pv-migrate migrate \
 
 
 **For further customization on the rendered manifests** (custom labels, annotations etc.), see the [Helm chart values](helm/pv-migrate).
-

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -21,6 +21,7 @@ const (
 	FlagSourceContext    = "source-context"
 	FlagSourceNamespace  = "source-namespace"
 	FlagSourcePath       = "source-path"
+	FlagSourceDnsSuffix  = "source-dns-suffix"
 
 	FlagDestKubeconfig   = "dest-kubeconfig"
 	FlagDestContext      = "dest-context"
@@ -93,6 +94,7 @@ func setMigrateCmdFlags(cmd *cobra.Command) {
 	flags.StringP(FlagSourceContext, "c", "", "context in the kubeconfig file of the source PVC")
 	flags.StringP(FlagSourceNamespace, "n", "", "namespace of the source PVC")
 	flags.StringP(FlagSourcePath, "p", "/", "the filesystem path to migrate in the source PVC")
+	flags.StringP(FlagSourceDnsSuffix, "S", "", "dns suffix for source cluster (for inter-cluster services)")
 
 	flags.StringP(FlagDestKubeconfig, "K", "", "path of the kubeconfig file of the destination PVC")
 	flags.StringP(FlagDestContext, "C", "", "context in the kubeconfig file of the destination PVC")
@@ -143,6 +145,7 @@ func runMigration(cmd *cobra.Command, args []string) error {
 	helmSetFile, _ := flags.GetStringSlice(FlagHelmSetFile)
 	strs, _ := flags.GetStringSlice(FlagStrategies)
 	destHostOverride, _ := flags.GetString(FlagDestHostOverride)
+	srcDnsSuffix, _ := flags.GetString(FlagSourceDnsSuffix)
 
 	deleteExtraneousFiles, _ := flags.GetBool(FlagDestDeleteExtraneousFiles)
 	request := migration.Request{
@@ -161,6 +164,7 @@ func runMigration(cmd *cobra.Command, args []string) error {
 		HelmFileValues:        helmSetFile,
 		Strategies:            strs,
 		DestHostOverride:      destHostOverride,
+		SourceDnsSuffix:       srcDnsSuffix,
 		Logger:                logger,
 	}
 

--- a/migration/types.go
+++ b/migration/types.go
@@ -34,6 +34,7 @@ type Request struct {
 	Strategies            []string
 	Logger                *log.Entry
 	DestHostOverride      string
+	SourceDnsSuffix       string
 }
 
 type Migration struct {


### PR DESCRIPTION
Add a flag indicating the cluster DNS suffix for the source cluster. If present, lbsvc strat should use the fully qualified DNS name for a ClusterIP service instead of a LoadBalancer service.  This allows transfers between bare-metal clusters where Service IPs are reachable between clusters (Calico BGP to ToR switch, etc).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
