### PR TITLE
refactor: fix goreleaser deprecations and improve Docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ archives:
       {{- with .Arm }}v{{ . }}{{ end }}
       {{- with .Mips }}_{{ . }}{{ end }}
       {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
-    builds:
+    ids:
       - pv-migrate
     format_overrides:
       - goos: windows
@@ -73,47 +73,24 @@ changelog:
       - Merge branch
       - go mod tidy
 
-dockers:
-  - image_templates:
-      - docker.io/utkuozdemir/pv-migrate:{{ .Tag }}-amd64
-      - ghcr.io/utkuozdemir/pv-migrate:{{ .Tag }}-amd64
-    use: buildx
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - --platform=linux/amd64
-  - image_templates:
-      - docker.io/utkuozdemir/pv-migrate:{{ .Tag }}-arm64
-      - ghcr.io/utkuozdemir/pv-migrate:{{ .Tag }}-arm64
-    use: buildx
-    goarch: arm64
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - --platform=linux/arm64
-  - image_templates:
-      - docker.io/utkuozdemir/pv-migrate:{{ .Tag }}-armv7
-      - ghcr.io/utkuozdemir/pv-migrate:{{ .Tag }}-armv7
-    use: buildx
-    goarch: arm
-    goarm: "7"
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - --platform=linux/arm/v7
-
-docker_manifests:
-  - name_template: docker.io/utkuozdemir/pv-migrate:{{ .Tag }}
-    image_templates:
-      - docker.io/utkuozdemir/pv-migrate:{{ .Tag }}-amd64
-      - docker.io/utkuozdemir/pv-migrate:{{ .Tag }}-arm64
-      - docker.io/utkuozdemir/pv-migrate:{{ .Tag }}-armv7
-  - name_template: ghcr.io/utkuozdemir/pv-migrate:{{ .Tag }}
-    image_templates:
-      - ghcr.io/utkuozdemir/pv-migrate:{{ .Tag }}-amd64
-      - ghcr.io/utkuozdemir/pv-migrate:{{ .Tag }}-arm64
-      - ghcr.io/utkuozdemir/pv-migrate:{{ .Tag }}-armv7
+dockers_v2:
+  - images:
+      - docker.io/utkuozdemir/pv-migrate
+      - ghcr.io/utkuozdemir/pv-migrate
+    tags:
+      - "{{ .Tag }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/arm/v7
 
 release:
   prerelease: auto
 
+# brews is deprecated in favor of homebrew_casks, but casks are unsuitable for CLI tools:
+# they don't upgrade with `brew upgrade` by default, and require macOS code signing.
+# See: https://github.com/orgs/goreleaser/discussions/5563
 brews:
   - repository:
       owner: utkuozdemir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,5 @@
-FROM alpine:3.23.3
-COPY pv-migrate /usr/local/bin/pv-migrate
+FROM scratch
+COPY --from=alpine:3.23.3 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+ARG TARGETPLATFORM=linux/amd64
+COPY ${TARGETPLATFORM}/pv-migrate /pv-migrate
+ENTRYPOINT ["/pv-migrate"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ Alternatively, you can use the
 [official Docker images](https://hub.docker.com/repository/docker/utkuozdemir/pv-migrate)
 that come with the `pv-migrate` binary pre-installed:
 ```bash
-docker run --rm -it utkuozdemir/pv-migrate:<IMAGE_TAG> pv-migrate --source <source-pvc> --dest <dest-pvc> ...
+docker run --rm -it utkuozdemir/pv-migrate:<IMAGE_TAG> --source <source-pvc> --dest <dest-pvc> ...
 ```
 
 ## Installing Shell Completion


### PR DESCRIPTION
Fix archives.builds and dockers/docker_manifests deprecations by migrating to the new ids and dockers_v2 syntax. Add a latest tag for non-prerelease Docker images. Switch base image from alpine to scratch and add an ENTRYPOINT. Keep brews as-is since homebrew_casks is unsuitable for CLI tools.

Closes #338.