### PR TITLE
fix: add SSH keepalive options to prevent broken pipes over load balancers

### DIFF
--- a/internal/rsync/cmd.go
+++ b/internal/rsync/cmd.go
@@ -34,8 +34,14 @@ func (c *Cmd) Build() (string, error) {
 	}
 
 	sshArgs := []string{
-		"ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+		"ssh",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "ConnectTimeout=5",
+		// ServerAliveInterval/CountMax prevent intermediate load balancers and proxies
+		// from dropping idle SSH connections during long file-list-building phases.
+		"-o", "ServerAliveInterval=10",
+		"-o", "ServerAliveCountMax=3",
 	}
 	if c.Port != 0 {
 		sshArgs = append(sshArgs, "-p", strconv.Itoa(c.Port))


### PR DESCRIPTION
Adds ServerAliveInterval=10 and ServerAliveCountMax=3 to the SSH client args used by rsync. This prevents intermediate load balancers (e.g. AWS ELB with 60s idle timeout) from dropping the connection during long file-list-building phases caused by --no-inc-recursive.

Closes #320
