### PR TITLE
refactor: merge helm values in memory instead of using temp file

### DIFF
--- a/cmd/pv-migrate/main.go
+++ b/cmd/pv-migrate/main.go
@@ -28,14 +28,14 @@ func run() int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCmd, err := app.BuildMigrateCmd(ctx, version, commit, date)
+	rootCmd, err := app.BuildMigrateCmd(ctx, version, commit, date, nil)
 	if err != nil {
 		slog.Default().Error("❌ Failed to build command", "error", err.Error())
 
 		return 1
 	}
 
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
+	if err = rootCmd.ExecuteContext(ctx); err != nil {
 		slog.Default().Error("❌ Failed to run", "error", err.Error())
 
 		return 1

--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,12 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.48.0
 	golang.org/x/sync v0.19.0
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.1.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/cli-runtime v0.35.2
 	k8s.io/client-go v0.35.2
+	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 )
 
@@ -132,10 +132,10 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/apiserver v0.35.1 // indirect
 	k8s.io/component-base v0.35.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	k8s.io/kubectl v0.35.1 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/remotecommand"
 	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/env"
 
 	"github.com/utkuozdemir/pv-migrate/internal/app"
@@ -84,6 +85,8 @@ var (
 
 func TestIntegration(t *testing.T) {
 	logger := slogt.New(t)
+	slog.SetDefault(logger)
+	klog.SetSlogLogger(logger)
 
 	setup(t, logger)
 	teardownOnCleanup(t, logger)
@@ -1012,14 +1015,14 @@ func runCliApp(ctx context.Context, t *testing.T, cmd string) error {
 func runCliAppWithArgs(ctx context.Context, t *testing.T, args ...string) error {
 	t.Logf("running command: %s", strings.Join(args, " "))
 
-	cliApp, err := app.BuildMigrateCmd(ctx, "", "", "")
+	cliApp, err := app.BuildMigrateCmd(ctx, "", "", "", slogt.New(t))
 	if err != nil {
 		return fmt.Errorf("failed to build command: %w", err)
 	}
 
 	cliApp.SetArgs(args)
 
-	if err := cliApp.Execute(); err != nil {
+	if err = cliApp.Execute(); err != nil {
 		return fmt.Errorf("failed to execute command: %w", err)
 	}
 
@@ -1072,4 +1075,3 @@ func getImages(t *testing.T) (rsyncImage, sshdImage string) {
 
 	return rsyncImage, sshdImage
 }
-

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lmittmann/tint"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/utkuozdemir/pv-migrate/internal/util"
 	"github.com/utkuozdemir/pv-migrate/pvmigrate"
@@ -83,7 +84,7 @@ type Options struct {
 	keyAlgorithm string
 }
 
-func BuildMigrateCmd(ctx context.Context, version, commit, date string) (*cobra.Command, error) {
+func BuildMigrateCmd(ctx context.Context, version, commit, date string, logger *slog.Logger) (*cobra.Command, error) {
 	versionStr := fmt.Sprintf("%s (commit: %s) (build date: %s)", version, commit, date)
 	use := fmt.Sprintf(
 		"%s [--%s=<source-ns>] --%s=<source-pvc> [--%s=<dest-ns>] --%s=<dest-pvc>",
@@ -113,7 +114,7 @@ func BuildMigrateCmd(ctx context.Context, version, commit, date string) (*cobra.
 		Args:    cobra.NoArgs,
 		Version: versionStr,
 		RunE: func(cmd *cobra.Command, _ []string) error { //nolint:contextcheck
-			return runMigration(cmd, &options, writer, isATTY)
+			return runMigration(cmd, &options, writer, isATTY, logger)
 		},
 	}
 
@@ -279,12 +280,15 @@ func setMigrateCmdFlags(cmd *cobra.Command, options *Options, logLevels, logForm
 	return nil
 }
 
-func runMigration(cmd *cobra.Command, options *Options, writer io.Writer, isATTY bool) error {
+func runMigration(cmd *cobra.Command, options *Options, writer io.Writer, isATTY bool, logger *slog.Logger) error {
 	ctx := cmd.Context()
 
-	logger, err := buildLogger(options.LogLevel, options.LogFormat, writer, isATTY)
-	if err != nil {
-		return fmt.Errorf("failed to build logger: %w", err)
+	if logger == nil { // no external logger, build the default logger with options and override the globals
+		var err error
+
+		if logger, err = buildLogger(options.LogLevel, options.LogFormat, writer, isATTY); err != nil {
+			return fmt.Errorf("failed to build logger: %w", err)
+		}
 	}
 
 	options.Migration.Strategies = util.ConvertStrings[pvmigrate.Strategy](options.strategies)
@@ -298,7 +302,7 @@ func runMigration(cmd *cobra.Command, options *Options, writer io.Writer, isATTY
 		logger.Info("❕ Extraneous files will be deleted from the destination")
 	}
 
-	if err = pvmigrate.Run(ctx, options.Migration); err != nil {
+	if err := pvmigrate.Run(ctx, options.Migration); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 
@@ -331,6 +335,7 @@ func buildLogger(logLevel, logFormat string, writer io.Writer, isATTY bool) (*sl
 
 	slog.SetLogLoggerLevel(level)
 	slog.SetDefault(logger)
+	klog.SetSlogLogger(logger)
 
 	return logger, nil
 }

--- a/internal/strategy/local.go
+++ b/internal/strategy/local.go
@@ -280,13 +280,6 @@ func installLocalOnDest(
 		},
 	}
 
-	valsFile, err := writeHelmValuesToTempFile("", vals)
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = os.Remove(valsFile) }()
-
 	return installHelmChart(attempt, destInfo, releaseName, vals, logger)
 }
 

--- a/internal/strategy/merge_values_test.go
+++ b/internal/strategy/merge_values_test.go
@@ -1,0 +1,361 @@
+package strategy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/neilotoole/slogt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/pv-migrate/internal/migration"
+)
+
+func TestGetMergedHelmValues_BaseOnly(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"sshd": map[string]any{
+			"enabled":   true,
+			"namespace": "default",
+			"publicKey": "ssh-ed25519 AAAA...",
+			"pvcMounts": []map[string]any{
+				{"name": "my-pvc", "mountPath": "/source", "readOnly": true},
+			},
+		},
+		"rsync": map[string]any{
+			"enabled":             true,
+			"namespace":           "default",
+			"privateKeyMount":     true,
+			"privateKey":          "-----BEGIN OPENSSH PRIVATE KEY-----",
+			"privateKeyMountPath": "/tmp/id_ed25519",
+			"command":             "rsync -avzs /source/ /dest/",
+			"pvcMounts": []map[string]any{
+				{"name": "my-pvc", "mountPath": "/dest"},
+			},
+		},
+	}
+
+	req := &migration.Request{}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(base, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	assert.Equal(t, true, gotSSHD["enabled"])
+	assert.Equal(t, "default", gotSSHD["namespace"])
+	assert.Equal(t, "ssh-ed25519 AAAA...", gotSSHD["publicKey"])
+
+	gotRsync, ok := got["rsync"].(map[string]any)
+	require.True(t, ok, "rsync key should be a map[string]any")
+
+	assert.Equal(t, true, gotRsync["enabled"])
+	assert.Equal(t, "rsync -avzs /source/ /dest/", gotRsync["command"])
+	assert.Equal(t, true, gotRsync["privateKeyMount"])
+}
+
+func TestGetMergedHelmValues_ImageTagInjected(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"sshd":  map[string]any{"enabled": true},
+		"rsync": map[string]any{"enabled": true},
+	}
+
+	req := &migration.Request{ImageTag: "v2.0.0"}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(base, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	sshdImage, ok := gotSSHD["image"].(map[string]any)
+	require.True(t, ok, "sshd.image should be a map[string]any")
+
+	assert.Equal(t, "v2.0.0", sshdImage["tag"])
+
+	gotRsync, ok := got["rsync"].(map[string]any)
+	require.True(t, ok, "rsync key should be a map[string]any")
+
+	rsyncImage, ok := gotRsync["image"].(map[string]any)
+	require.True(t, ok, "rsync.image should be a map[string]any")
+
+	assert.Equal(t, "v2.0.0", rsyncImage["tag"])
+}
+
+func TestGetMergedHelmValues_HelmSetOverridesBase(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"sshd": map[string]any{
+			"enabled":   true,
+			"namespace": "original-ns",
+		},
+	}
+
+	req := &migration.Request{
+		HelmValues: []string{"sshd.namespace=overridden-ns"},
+	}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(base, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	assert.Equal(t, "overridden-ns", gotSSHD["namespace"])
+	assert.Equal(t, true, gotSSHD["enabled"])
+}
+
+func TestGetMergedHelmValues_HelmSetOverridesImageTag(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"sshd":  map[string]any{"enabled": true},
+		"rsync": map[string]any{"enabled": true},
+	}
+
+	req := &migration.Request{
+		ImageTag:   "v2.0.0",
+		HelmValues: []string{"sshd.image.tag=custom-tag"},
+	}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(base, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	sshdImage, ok := gotSSHD["image"].(map[string]any)
+	require.True(t, ok, "sshd.image should be a map[string]any")
+
+	// --helm-set should override the ImageTag injection
+	assert.Equal(t, "custom-tag", sshdImage["tag"])
+
+	gotRsync, ok := got["rsync"].(map[string]any)
+	require.True(t, ok, "rsync key should be a map[string]any")
+
+	rsyncImage, ok := gotRsync["image"].(map[string]any)
+	require.True(t, ok, "rsync.image should be a map[string]any")
+
+	// rsync should still get the ImageTag value
+	assert.Equal(t, "v2.0.0", rsyncImage["tag"])
+}
+
+func TestGetMergedHelmValues_ValuesFileOverridesBase(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"sshd": map[string]any{
+			"enabled":   true,
+			"namespace": "original",
+			"publicKey": "ssh-ed25519 AAAA...",
+		},
+		"rsync": map[string]any{
+			"enabled": true,
+		},
+	}
+
+	valuesFile := filepath.Join(t.TempDir(), "override.yaml")
+	err := os.WriteFile(valuesFile, []byte(`
+sshd:
+  namespace: from-file
+  service:
+    type: LoadBalancer
+`), 0o600)
+	require.NoError(t, err)
+
+	req := &migration.Request{
+		HelmValuesFiles: []string{valuesFile},
+	}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(base, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	assert.Equal(t, "from-file", gotSSHD["namespace"])
+	assert.Equal(t, true, gotSSHD["enabled"])
+	assert.Equal(t, "ssh-ed25519 AAAA...", gotSSHD["publicKey"])
+
+	service, ok := gotSSHD["service"].(map[string]any)
+	require.True(t, ok, "sshd.service should be a map[string]any")
+
+	assert.Equal(t, "LoadBalancer", service["type"])
+
+	gotRsync, ok := got["rsync"].(map[string]any)
+	require.True(t, ok, "rsync key should be a map[string]any")
+
+	// rsync should be untouched
+	assert.Equal(t, true, gotRsync["enabled"])
+}
+
+func TestGetMergedHelmValues_FullPriorityOrder(t *testing.T) {
+	t.Parallel()
+
+	// base values (lowest priority)
+	base := map[string]any{
+		"sshd": map[string]any{
+			"enabled":   true,
+			"namespace": "from-base",
+			"publicKey": "base-key",
+		},
+	}
+
+	// values file (overrides base)
+	valuesFile := filepath.Join(t.TempDir(), "vals.yaml")
+	err := os.WriteFile(valuesFile, []byte(`
+sshd:
+  namespace: from-file
+  publicKey: file-key
+`), 0o600)
+	require.NoError(t, err)
+
+	// --helm-set (overrides values file)
+	req := &migration.Request{
+		HelmValuesFiles: []string{valuesFile},
+		HelmValues:      []string{"sshd.publicKey=set-key"},
+	}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(base, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	// base value preserved when not overridden
+	assert.Equal(t, true, gotSSHD["enabled"])
+	// file overrides base
+	assert.Equal(t, "from-file", gotSSHD["namespace"])
+	// --set overrides file
+	assert.Equal(t, "set-key", gotSSHD["publicKey"])
+}
+
+func realisticClusterIPBase() map[string]any {
+	return map[string]any{
+		"rsync": map[string]any{
+			"enabled":             true,
+			"namespace":           "dest-ns",
+			"privateKeyMount":     true,
+			"privateKey":          "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
+			"privateKeyMountPath": "/tmp/id_ed25519",
+			"pvcMounts":           []map[string]any{{"name": "dest-pvc", "mountPath": "/dest"}},
+			"command":             "rsync -avzs -e 'ssh -o StrictHostKeyChecking=no' /source/ sshd-host:/dest/",
+			"affinity":            map[string]any{},
+		},
+		"sshd": map[string]any{
+			"enabled":   true,
+			"namespace": "source-ns",
+			"publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...",
+			"pvcMounts": []map[string]any{{"name": "source-pvc", "mountPath": "/source", "readOnly": true}},
+			"affinity":  map[string]any{},
+		},
+	}
+}
+
+func TestGetMergedHelmValues_RealisticRsyncValues(t *testing.T) {
+	t.Parallel()
+
+	req := &migration.Request{ImageTag: "v2.2.1"}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(realisticClusterIPBase(), req, logger)
+	require.NoError(t, err)
+
+	gotRsync, ok := got["rsync"].(map[string]any)
+	require.True(t, ok, "rsync key should be a map[string]any")
+
+	assert.Equal(t, true, gotRsync["enabled"])
+	assert.Equal(t, "dest-ns", gotRsync["namespace"])
+	assert.Equal(t, true, gotRsync["privateKeyMount"])
+	assert.Equal(t, "/tmp/id_ed25519", gotRsync["privateKeyMountPath"])
+
+	rsyncImage, ok := gotRsync["image"].(map[string]any)
+	require.True(t, ok, "rsync.image should be a map[string]any")
+
+	assert.Equal(t, "v2.2.1", rsyncImage["tag"])
+}
+
+func TestGetMergedHelmValues_RealisticSSHDValues(t *testing.T) {
+	t.Parallel()
+
+	req := &migration.Request{ImageTag: "v2.2.1"}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(realisticClusterIPBase(), req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	assert.Equal(t, true, gotSSHD["enabled"])
+	assert.Equal(t, "source-ns", gotSSHD["namespace"])
+	assert.Equal(t, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...", gotSSHD["publicKey"])
+
+	sshdImage, ok := gotSSHD["image"].(map[string]any)
+	require.True(t, ok, "sshd.image should be a map[string]any")
+
+	assert.Equal(t, "v2.2.1", sshdImage["tag"])
+
+	// Verify pvcMounts are preserved
+	sshdMounts, ok := gotSSHD["pvcMounts"].([]map[string]any)
+	require.True(t, ok, "sshd.pvcMounts should be a []map[string]any")
+	require.Len(t, sshdMounts, 1)
+
+	assert.Equal(t, "source-pvc", sshdMounts[0]["name"])
+	assert.Equal(t, "/source", sshdMounts[0]["mountPath"])
+	assert.Equal(t, true, sshdMounts[0]["readOnly"])
+}
+
+func TestGetMergedHelmValues_EmptyBase(t *testing.T) {
+	t.Parallel()
+
+	req := &migration.Request{
+		HelmValues: []string{"sshd.enabled=true"},
+	}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(map[string]any{}, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	assert.Equal(t, true, gotSSHD["enabled"])
+}
+
+func TestGetMergedHelmValues_StringValuesOverride(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"sshd": map[string]any{
+			"enabled": true,
+		},
+	}
+
+	req := &migration.Request{
+		// --set-string always produces string values
+		HelmStringValues: []string{"sshd.namespace=string-ns"},
+	}
+	logger := slogt.New(t)
+
+	got, err := getMergedHelmValues(base, req, logger)
+	require.NoError(t, err)
+
+	gotSSHD, ok := got["sshd"].(map[string]any)
+	require.True(t, ok, "sshd key should be a map[string]any")
+
+	assert.Equal(t, true, gotSSHD["enabled"])
+	assert.Equal(t, "string-ns", gotSSHD["namespace"])
+}

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/cli/values"
 	"helm.sh/helm/v4/pkg/getter"
@@ -30,8 +30,6 @@ const (
 	loadBalancerStrategy = "loadbalancer"
 	localStrategy        = "local"
 	nodePortStrategy     = "nodeport"
-
-	helmValuesYAMLIndent = 2
 
 	srcMountPath  = "/source"
 	destMountPath = "/dest"
@@ -174,11 +172,11 @@ func initHelmActionConfig(pvcInfo *pvc.Info) (*action.Configuration, error) {
 }
 
 func getMergedHelmValues(
-	helmValuesFile string,
+	baseValues map[string]any,
 	request *migration.Request,
 	logger *slog.Logger,
 ) (map[string]any, error) {
-	// If an image tag is set, inject it as the lowest-priority values
+	// If an image tag is set, inject it as the lowest-priority --set values
 	// so user overrides via --helm-set take precedence.
 	helmValues := request.HelmValues
 	if tag := request.ImageTag; tag != "" {
@@ -189,18 +187,20 @@ func getMergedHelmValues(
 		helmValues = append(imageTagValues, helmValues...)
 	}
 
-	allValuesFiles := append([]string{helmValuesFile}, request.HelmValuesFiles...)
 	valsOptions := values.Options{
+		ValueFiles:   request.HelmValuesFiles,
 		Values:       helmValues,
-		ValueFiles:   allValuesFiles,
 		StringValues: request.HelmStringValues,
 		FileValues:   request.HelmFileValues,
 	}
 
-	mergedValues, err := valsOptions.MergeValues(helmProviders)
+	userValues, err := valsOptions.MergeValues(helmProviders)
 	if err != nil {
 		return nil, fmt.Errorf("failed to merge helm values: %w", err)
 	}
+
+	// Merge using Helm's own MergeMaps: user values override base values.
+	merged := loader.MergeMaps(baseValues, userValues)
 
 	if request.ImageTag != "" {
 		logger.Info("🏷️ Using image tag", "tag", request.ImageTag)
@@ -208,7 +208,7 @@ func getMergedHelmValues(
 		logger.Info("🏷️ Using chart default image tags")
 	}
 
-	return mergedValues, nil
+	return merged, nil
 }
 
 func installHelmChart(
@@ -218,17 +218,6 @@ func installHelmChart(
 	values map[string]any,
 	logger *slog.Logger,
 ) error {
-	helmValuesFile, err := writeHelmValuesToTempFile(attempt.ID, values)
-	if err != nil {
-		return fmt.Errorf("failed to write helm values to temp file: %w", err)
-	}
-
-	defer func() {
-		if removeErr := os.Remove(helmValuesFile); removeErr != nil {
-			logger.Warn("🔶 Failed to remove temp helm values file", "error", removeErr)
-		}
-	}()
-
 	helmActionConfig, err := initHelmActionConfig(pvcInfo)
 	if err != nil {
 		return fmt.Errorf("failed to init helm action config: %w", err)
@@ -247,7 +236,7 @@ func installHelmChart(
 		install.Timeout = req.HelmTimeout
 	}
 
-	vals, err := getMergedHelmValues(helmValuesFile, mig.Request, logger)
+	vals, err := getMergedHelmValues(values, mig.Request, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get merged helm values: %w", err)
 	}
@@ -257,23 +246,4 @@ func installHelmChart(
 	}
 
 	return nil
-}
-
-func writeHelmValuesToTempFile(id string, vals map[string]any) (string, error) {
-	file, err := os.CreateTemp("", fmt.Sprintf("pv-migrate-vals-%s-*.yaml", id))
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp file for helm values: %w", err)
-	}
-
-	defer func() { _ = file.Close() }()
-
-	encoder := yaml.NewEncoder(file)
-	encoder.SetIndent(helmValuesYAMLIndent)
-
-	err = encoder.Encode(vals)
-	if err != nil {
-		return "", fmt.Errorf("failed to encode helm values: %w", err)
-	}
-
-	return file.Name(), nil
 }


### PR DESCRIPTION
Use Helm's own loader.MergeMaps to merge programmatic base values with user-provided overrides, eliminating the temp file round-trip through writeHelmValuesToTempFile.
