### PR TITLE
feat: fail early when destination PVC is smaller than source

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -37,6 +37,7 @@ Flags:
   -h, --help                            help for pv-migrate
       --id string                       Custom operation ID (lowercase alphanumeric with optional hyphens, max 28 chars). If not set, a random ID is generated. Used to identify the operation in 'status' and 'cleanup' commands
   -i, --ignore-mounted                  Do not fail if the source or destination PVC is mounted
+      --ignore-sizes                    Do not fail if the destination PVC is smaller than the source PVC
       --loadbalancer-timeout duration   Timeout for the load balancer to receive an external IP. Only used by the loadbalancer strategy (default 2m0s)
       --log-format string               Log format, one of text, json (default "text")
       --log-level string                Log level, one of DEBUG, INFO, WARN, ERROR or an slog-parseable level: https://pkg.go.dev/log/slog#Level.UnmarshalText (default "INFO")

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -71,6 +71,7 @@ const (
 
 	FlagDestDeleteExtraneousFiles = "dest-delete-extraneous-files"
 	FlagIgnoreMounted             = "ignore-mounted"
+	FlagIgnoreSizes               = "ignore-sizes"
 	FlagNoChown                   = "no-chown"
 	FlagDetach                    = "detach"
 	FlagNoCleanup                 = "no-cleanup"
@@ -296,6 +297,8 @@ func setMigrateCmdFlags(cmd *cobra.Command, options *Options, logLevels, logForm
 	)
 	flags.BoolVarP(&migration.IgnoreMounted, FlagIgnoreMounted, "i", migration.IgnoreMounted,
 		"Do not fail if the source or destination PVC is mounted")
+	flags.BoolVar(&migration.IgnoreSizes, FlagIgnoreSizes, migration.IgnoreSizes,
+		"Do not fail if the destination PVC is smaller than the source PVC")
 	flags.BoolVarP(&migration.NoChown, FlagNoChown, "o", migration.NoChown, "Omit chown during rsync")
 	flags.StringVar(&migration.ID, FlagID, migration.ID,
 		"Custom operation ID (lowercase alphanumeric with optional hyphens, max 28 chars). "+

--- a/internal/migration/types.go
+++ b/internal/migration/types.go
@@ -25,6 +25,7 @@ type Request struct {
 	Dest                  PVCInfo
 	DeleteExtraneousFiles bool
 	IgnoreMounted         bool
+	IgnoreSizes           bool
 	NoChown               bool
 	Detach                bool
 	Push                  bool

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -246,12 +246,16 @@ func handleMountedPVCs(
 
 // validatePVCs runs the pre-flight checks on the resolved source and
 // destination PVCs before the migration is attempted.
-func validatePVCs(r *migration.Request, sourceInfo, destInfo *pvc.Info, logger *slog.Logger) error {
+func validatePVCs(request *migration.Request, sourceInfo, destInfo *pvc.Info, logger *slog.Logger) error {
+	if sourceInfo == nil || sourceInfo.Claim == nil || destInfo == nil || destInfo.Claim == nil {
+		return errors.New("source or destination PVC info is invalid")
+	}
+
 	if !destInfo.SupportsRWO && !destInfo.SupportsRWX {
 		return errors.New("destination PVC is not writable")
 	}
 
-	return handleSizes(r, sourceInfo, destInfo, logger)
+	return handleSizes(request, sourceInfo, destInfo, logger)
 }
 
 // handleSizes fails early when the destination PVC is smaller than the source

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -188,7 +188,7 @@ func (m *Migrator) buildMigration(ctx context.Context, request *migration.Reques
 		return nil, err
 	}
 
-	if err = validatePVCs(request, sourcePvcInfo, destPvcInfo, logger); err != nil {
+	if err = validatePVCs(ctx, request, sourcePvcInfo, destPvcInfo, logger); err != nil {
 		return nil, err
 	}
 
@@ -246,7 +246,12 @@ func handleMountedPVCs(
 
 // validatePVCs runs the pre-flight checks on the resolved source and
 // destination PVCs before the migration is attempted.
-func validatePVCs(request *migration.Request, sourceInfo, destInfo *pvc.Info, logger *slog.Logger) error {
+func validatePVCs(
+	ctx context.Context,
+	request *migration.Request,
+	sourceInfo, destInfo *pvc.Info,
+	logger *slog.Logger,
+) error {
 	if sourceInfo == nil || sourceInfo.Claim == nil || destInfo == nil || destInfo.Claim == nil {
 		return errors.New("source or destination PVC info is invalid")
 	}
@@ -255,19 +260,26 @@ func validatePVCs(request *migration.Request, sourceInfo, destInfo *pvc.Info, lo
 		return errors.New("destination PVC is not writable")
 	}
 
-	return handleSizes(request, sourceInfo, destInfo, logger)
+	return handleSizes(ctx, request, sourceInfo, destInfo, logger)
 }
 
 // handleSizes fails early when the destination PVC is smaller than the source
 // PVC. Such a migration would otherwise typically fail midway with a generic
 // "all strategies failed" error once the destination runs out of space.
 // The check compares the resolved storage sizes (see pvc.Info.Size) and is
-// skipped when --ignore-sizes is requested or when either size is unknown.
-func handleSizes(r *migration.Request, sourceInfo, destInfo *pvc.Info, logger *slog.Logger) error {
+// skipped when --ignore-sizes is requested, when either size is unknown, or when
+// either PVC's storage provisioner does not enforce the requested capacity (see
+// capacityEnforced), in which case the declared sizes are meaningless.
+func handleSizes(
+	ctx context.Context,
+	request *migration.Request,
+	sourceInfo, destInfo *pvc.Info,
+	logger *slog.Logger,
+) error {
 	sourceSize := sourceInfo.Size()
 	destSize := destInfo.Size()
 
-	if r.IgnoreSizes {
+	if request.IgnoreSizes {
 		logger.Info("💡 --ignore-sizes is requested, skipping PVC size check",
 			"source_size", sourceSize.String(), "dest_size", destSize.String())
 
@@ -281,15 +293,64 @@ func handleSizes(r *migration.Request, sourceInfo, destInfo *pvc.Info, logger *s
 		return nil
 	}
 
-	if destSize.Cmp(sourceSize) < 0 {
-		return fmt.Errorf("destination PVC %s/%s (%s) is smaller than source PVC %s/%s (%s): "+
-			"the migration would likely fail once the destination runs out of space. "+
-			"If you are sure the data fits, re-run with --ignore-sizes",
-			destInfo.Claim.Namespace, destInfo.Claim.Name, destSize.String(),
-			sourceInfo.Claim.Namespace, sourceInfo.Claim.Name, sourceSize.String())
+	if destSize.Cmp(sourceSize) >= 0 {
+		return nil
 	}
 
-	return nil
+	// The destination is smaller than the source. This only leads to a failure
+	// if the provisioner actually enforces the requested capacity. Many local
+	// provisioners (e.g. rancher.io/local-path) ignore it, so the sizes are
+	// meaningless and the check would be a false positive.
+	for _, candidate := range []struct {
+		role string
+		info *pvc.Info
+	}{
+		{role: "source", info: sourceInfo},
+		{role: "destination", info: destInfo},
+	} {
+		provisioner, err := candidate.info.Provisioner(ctx)
+		if err != nil {
+			logger.Debug("Could not resolve PVC storage provisioner, continuing with size check",
+				"pvc", candidate.info.Claim.Namespace+"/"+candidate.info.Claim.Name, "error", err.Error())
+		}
+
+		if !capacityEnforced(provisioner) {
+			logger.Info("💡 PVC storage provisioner does not enforce capacity, skipping PVC size check",
+				"role", candidate.role, "provisioner", provisioner,
+				"source_size", sourceSize.String(), "dest_size", destSize.String())
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("destination PVC %s/%s (%s) is smaller than source PVC %s/%s (%s): "+
+		"the migration would likely fail once the destination runs out of space. "+
+		"If you are sure the data fits, re-run with --ignore-sizes",
+		destInfo.Claim.Namespace, destInfo.Claim.Name, destSize.String(),
+		sourceInfo.Claim.Namespace, sourceInfo.Claim.Name, sourceSize.String())
+}
+
+// capacityEnforced reports whether a storage provisioner enforces the requested
+// volume capacity. Several common local provisioners ignore it (rancher.io/local-path
+// used by k3s/k3d/kind/OrbStack, the minikube/MicroK8s/Docker Desktop hostpath
+// provisioners, OpenEBS LocalPV, etc.), so the PVC size is effectively a no-op and
+// comparing source and destination sizes is meaningless. An empty or unknown
+// provisioner is treated as enforcing, so the size check still runs by default.
+func capacityEnforced(provisioner string) bool {
+	if provisioner == "" {
+		return true
+	}
+
+	p := strings.ToLower(provisioner)
+
+	switch {
+	case strings.Contains(p, "local-path"),
+		strings.Contains(p, "hostpath"),
+		p == "openebs.io/local":
+		return false
+	default:
+		return true
+	}
 }
 
 func handleMounted(info *pvc.Info, ignoreMounted bool, logger *slog.Logger) error {

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -188,8 +188,8 @@ func (m *Migrator) buildMigration(ctx context.Context, request *migration.Reques
 		return nil, err
 	}
 
-	if !destPvcInfo.SupportsRWO && !destPvcInfo.SupportsRWX {
-		return nil, errors.New("destination PVC is not writable")
+	if err = validatePVCs(request, sourcePvcInfo, destPvcInfo, logger); err != nil {
+		return nil, err
 	}
 
 	mig := migration.Migration{
@@ -239,6 +239,50 @@ func handleMountedPVCs(
 	err = handleMounted(destPvcInfo, ignoreMounted, logger)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// validatePVCs runs the pre-flight checks on the resolved source and
+// destination PVCs before the migration is attempted.
+func validatePVCs(r *migration.Request, sourceInfo, destInfo *pvc.Info, logger *slog.Logger) error {
+	if !destInfo.SupportsRWO && !destInfo.SupportsRWX {
+		return errors.New("destination PVC is not writable")
+	}
+
+	return handleSizes(r, sourceInfo, destInfo, logger)
+}
+
+// handleSizes fails early when the destination PVC is smaller than the source
+// PVC. Such a migration would otherwise typically fail midway with a generic
+// "all strategies failed" error once the destination runs out of space.
+// The check compares the resolved storage sizes (see pvc.Info.Size) and is
+// skipped when --ignore-sizes is requested or when either size is unknown.
+func handleSizes(r *migration.Request, sourceInfo, destInfo *pvc.Info, logger *slog.Logger) error {
+	sourceSize := sourceInfo.Size()
+	destSize := destInfo.Size()
+
+	if r.IgnoreSizes {
+		logger.Info("💡 --ignore-sizes is requested, skipping PVC size check",
+			"source_size", sourceSize.String(), "dest_size", destSize.String())
+
+		return nil
+	}
+
+	if sourceSize.IsZero() || destSize.IsZero() {
+		logger.Debug("Skipping PVC size check, capacity unknown for source or destination",
+			"source_size", sourceSize.String(), "dest_size", destSize.String())
+
+		return nil
+	}
+
+	if destSize.Cmp(sourceSize) < 0 {
+		return fmt.Errorf("destination PVC %s/%s (%s) is smaller than source PVC %s/%s (%s): "+
+			"the migration would likely fail once the destination runs out of space. "+
+			"If you are sure the data fits, re-run with --ignore-sizes",
+			destInfo.Claim.Namespace, destInfo.Claim.Name, destSize.String(),
+			sourceInfo.Claim.Namespace, sourceInfo.Claim.Name, sourceSize.String())
 	}
 
 	return nil

--- a/internal/migrator/migrator_test.go
+++ b/internal/migrator/migrator_test.go
@@ -110,6 +110,46 @@ func TestBuildMigrationSizeCheck(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, tsk)
 	})
+
+	t.Run("succeeds when destination is smaller but its provisioner does not enforce capacity", func(t *testing.T) {
+		t.Parallel()
+
+		m := Migrator{getKubeClient: fakeClusterClientGetterWithProvisioner("2Gi", "1Gi", "rancher.io/local-path")}
+		req := buildMigration(true)
+
+		tsk, err := m.buildMigration(t.Context(), req, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, tsk)
+	})
+}
+
+func TestCapacityEnforced(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		provisioner string
+		want        bool
+	}{
+		"rancher local-path":      {provisioner: "rancher.io/local-path", want: false},
+		"minikube hostpath":       {provisioner: "k8s.io/minikube-hostpath", want: false},
+		"microk8s hostpath":       {provisioner: "microk8s.io/hostpath", want: false},
+		"docker desktop hostpath": {provisioner: "docker.io/hostpath", want: false},
+		"kubevirt hostpath":       {provisioner: "kubevirt.io/hostpath-provisioner", want: false},
+		"kubevirt hostpath csi":   {provisioner: "kubevirt.io.hostpath-provisioner", want: false},
+		"openebs local":           {provisioner: "openebs.io/local", want: false},
+		"aws ebs csi":             {provisioner: "ebs.csi.aws.com", want: true},
+		"gce pd csi":              {provisioner: "pd.csi.storage.gke.io", want: true},
+		"local static":            {provisioner: "local-volume-provisioner-node-abc123", want: true},
+		"unknown empty":           {provisioner: "", want: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, capacityEnforced(tt.provisioner))
+		})
+	}
 }
 
 func TestRunStrategiesInOrder(t *testing.T) {
@@ -191,8 +231,19 @@ func fakeClusterClientGetter() clusterClientGetter {
 }
 
 func fakeClusterClientGetterWithSizes(sourceSize, destSize string) clusterClientGetter {
+	return fakeClusterClientGetterWithProvisioner(sourceSize, destSize, "")
+}
+
+func fakeClusterClientGetterWithProvisioner(sourceSize, destSize, destProvisioner string) clusterClientGetter {
 	pvcA := buildTestPVC(sourceNS, sourcePVC, sourceSize, corev1.ReadOnlyMany)
 	pvcB := buildTestPVC(destNS, destPVC, destSize, corev1.ReadWriteOnce, corev1.ReadWriteMany)
+
+	if destProvisioner != "" {
+		pvcB.Annotations = map[string]string{
+			"volume.kubernetes.io/storage-provisioner": destProvisioner,
+		}
+	}
+
 	podA := buildTestPod(sourceNS, sourcePod, sourceNode, sourcePVC)
 	podB := buildTestPod(destNS, destPod, destNode, destPVC)
 

--- a/internal/migrator/migrator_test.go
+++ b/internal/migrator/migrator_test.go
@@ -71,6 +71,47 @@ func TestBuildTaskMounted(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestBuildMigrationSizeCheck(t *testing.T) {
+	t.Parallel()
+
+	logger := slogt.New(t)
+
+	t.Run("fails when destination is smaller than source", func(t *testing.T) {
+		t.Parallel()
+
+		m := Migrator{getKubeClient: fakeClusterClientGetterWithSizes("2Gi", "1Gi")}
+		req := buildMigration(true)
+
+		tsk, err := m.buildMigration(t.Context(), req, logger)
+		assert.Nil(t, tsk)
+		require.ErrorContains(t, err, "smaller than source")
+		require.ErrorContains(t, err, "--ignore-sizes")
+	})
+
+	t.Run("succeeds when destination is smaller but --ignore-sizes is set", func(t *testing.T) {
+		t.Parallel()
+
+		m := Migrator{getKubeClient: fakeClusterClientGetterWithSizes("2Gi", "1Gi")}
+		req := buildMigration(true)
+		req.IgnoreSizes = true
+
+		tsk, err := m.buildMigration(t.Context(), req, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, tsk)
+	})
+
+	t.Run("succeeds when destination is larger than source", func(t *testing.T) {
+		t.Parallel()
+
+		m := Migrator{getKubeClient: fakeClusterClientGetterWithSizes("1Gi", "2Gi")}
+		req := buildMigration(true)
+
+		tsk, err := m.buildMigration(t.Context(), req, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, tsk)
+	})
+}
+
 func TestRunStrategiesInOrder(t *testing.T) {
 	t.Parallel()
 
@@ -146,8 +187,12 @@ func buildMigrationRequestWithStrategies(
 }
 
 func fakeClusterClientGetter() clusterClientGetter {
-	pvcA := buildTestPVC(sourceNS, sourcePVC, corev1.ReadOnlyMany)
-	pvcB := buildTestPVC(destNS, destPVC, corev1.ReadWriteOnce, corev1.ReadWriteMany)
+	return fakeClusterClientGetterWithSizes("512Mi", "512Mi")
+}
+
+func fakeClusterClientGetterWithSizes(sourceSize, destSize string) clusterClientGetter {
+	pvcA := buildTestPVC(sourceNS, sourcePVC, sourceSize, corev1.ReadOnlyMany)
+	pvcB := buildTestPVC(destNS, destPVC, destSize, corev1.ReadWriteOnce, corev1.ReadWriteMany)
 	podA := buildTestPod(sourceNS, sourcePod, sourceNode, sourcePVC)
 	podB := buildTestPod(destNS, destPod, destNode, destPVC)
 
@@ -177,7 +222,10 @@ func buildTestPod(ns, name, node, pvc string) *corev1.Pod {
 	}
 }
 
-func buildTestPVC(ns, name string, accessModes ...corev1.PersistentVolumeAccessMode) *corev1.PersistentVolumeClaim {
+func buildTestPVC(
+	ns, name, size string,
+	accessModes ...corev1.PersistentVolumeAccessMode,
+) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -187,7 +235,7 @@ func buildTestPVC(ns, name string, accessModes ...corev1.PersistentVolumeAccessM
 			AccessModes: accessModes,
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: map[corev1.ResourceName]resource.Quantity{
-					"storage": resource.MustParse("512Mi"),
+					"storage": resource.MustParse(size),
 				},
 			},
 		},

--- a/internal/pvc/info.go
+++ b/internal/pvc/info.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -79,6 +80,18 @@ func New(
 		SupportsROX:        supportsROX,
 		SupportsRWX:        supportsRWX,
 	}, nil
+}
+
+// Size returns the storage capacity of the PVC. It prefers the actual capacity
+// of the bound PersistentVolume (Status.Capacity) and falls back to the
+// requested capacity (Spec.Resources.Requests) when the PVC is not yet bound.
+// It returns a zero quantity when neither is set.
+func (i *Info) Size() resource.Quantity {
+	if capacity, ok := i.Claim.Status.Capacity[corev1.ResourceStorage]; ok && !capacity.IsZero() {
+		return capacity
+	}
+
+	return i.Claim.Spec.Resources.Requests[corev1.ResourceStorage]
 }
 
 func findMountedNode(ctx context.Context, kubeClient kubernetes.Interface,

--- a/internal/pvc/info.go
+++ b/internal/pvc/info.go
@@ -98,6 +98,55 @@ func (i *Info) Size() resource.Quantity {
 	return i.Claim.Spec.Resources.Requests[corev1.ResourceStorage]
 }
 
+const (
+	// storageProvisionerAnnotation is set on a PVC by the controller to record
+	// which provisioner handles its dynamic provisioning.
+	storageProvisionerAnnotation = "volume.kubernetes.io/storage-provisioner"
+	// betaStorageProvisionerAnnotation is the pre-1.23 form of the above; some
+	// clusters still carry it.
+	betaStorageProvisionerAnnotation = "volume.beta.kubernetes.io/storage-provisioner"
+)
+
+// Provisioner resolves the name of the storage provisioner backing the PVC on a
+// best-effort basis. It first reads the provisioner annotation set on the claim,
+// which is present once a dynamically provisioned PVC has been picked up by the
+// controller, then falls back to the provisioner of the claim's StorageClass.
+// The fallback is needed for PVCs that are not yet bound (e.g. those using the
+// WaitForFirstConsumer volume binding mode), whose annotation is not set yet.
+// It returns an empty name when the provisioner cannot be determined; the
+// returned error is non-nil only when a StorageClass lookup was attempted and
+// failed, so callers may treat it as best-effort.
+func (i *Info) Provisioner(ctx context.Context) (string, error) {
+	if i == nil || i.Claim == nil {
+		return "", nil
+	}
+
+	if provisioner := i.Claim.Annotations[storageProvisionerAnnotation]; provisioner != "" {
+		return provisioner, nil
+	}
+
+	if provisioner := i.Claim.Annotations[betaStorageProvisionerAnnotation]; provisioner != "" {
+		return provisioner, nil
+	}
+
+	storageClassName := i.Claim.Spec.StorageClassName
+	if storageClassName == nil || *storageClassName == "" {
+		return "", nil
+	}
+
+	if i.ClusterClient == nil || i.ClusterClient.KubeClient == nil {
+		return "", nil
+	}
+
+	storageClass, err := i.ClusterClient.KubeClient.StorageV1().
+		StorageClasses().Get(ctx, *storageClassName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get storage class %s: %w", *storageClassName, err)
+	}
+
+	return storageClass.Provisioner, nil
+}
+
 func findMountedNode(ctx context.Context, kubeClient kubernetes.Interface,
 	pvc *corev1.PersistentVolumeClaim,
 ) (string, error) {

--- a/internal/pvc/info.go
+++ b/internal/pvc/info.go
@@ -87,6 +87,10 @@ func New(
 // requested capacity (Spec.Resources.Requests) when the PVC is not yet bound.
 // It returns a zero quantity when neither is set.
 func (i *Info) Size() resource.Quantity {
+	if i == nil || i.Claim == nil {
+		return resource.Quantity{}
+	}
+
 	if capacity, ok := i.Claim.Status.Capacity[corev1.ResourceStorage]; ok && !capacity.IsZero() {
 		return capacity
 	}

--- a/internal/pvc/info_test.go
+++ b/internal/pvc/info_test.go
@@ -161,6 +161,18 @@ func TestSize(t *testing.T) {
 		size := info.Size()
 		assert.True(t, size.IsZero())
 	})
+
+	t.Run("returns zero for nil receiver or nil claim", func(t *testing.T) {
+		t.Parallel()
+
+		var nilInfo *pvc.Info
+
+		nilReceiverSize := nilInfo.Size()
+		assert.True(t, nilReceiverSize.IsZero())
+
+		nilClaimSize := (&pvc.Info{}).Size()
+		assert.True(t, nilClaimSize.IsZero())
+	})
 }
 
 func buildClusterClient(

--- a/internal/pvc/info_test.go
+++ b/internal/pvc/info_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -113,6 +114,52 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Empty(t, pvcInfo.MountedNode)
+	})
+}
+
+func TestSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefers actual capacity over requested", func(t *testing.T) {
+		t.Parallel()
+
+		info := &pvc.Info{Claim: &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
+			},
+		}}
+
+		size := info.Size()
+		assert.Equal(t, "2Gi", size.String())
+	})
+
+	t.Run("falls back to requested when not bound", func(t *testing.T) {
+		t.Parallel()
+
+		info := &pvc.Info{Claim: &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}}
+
+		size := info.Size()
+		assert.Equal(t, "1Gi", size.String())
+	})
+
+	t.Run("returns zero when nothing is set", func(t *testing.T) {
+		t.Parallel()
+
+		info := &pvc.Info{Claim: &corev1.PersistentVolumeClaim{}}
+
+		size := info.Size()
+		assert.True(t, size.IsZero())
 	})
 }
 

--- a/internal/pvc/info_test.go
+++ b/internal/pvc/info_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -172,6 +173,98 @@ func TestSize(t *testing.T) {
 
 		nilClaimSize := (&pvc.Info{}).Size()
 		assert.True(t, nilClaimSize.IsZero())
+	})
+}
+
+func TestProvisioner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads the storage-provisioner annotation", func(t *testing.T) {
+		t.Parallel()
+
+		info := &pvc.Info{Claim: &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"volume.kubernetes.io/storage-provisioner": "rancher.io/local-path",
+			}},
+		}}
+
+		provisioner, err := info.Provisioner(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "rancher.io/local-path", provisioner)
+	})
+
+	t.Run("reads the beta storage-provisioner annotation", func(t *testing.T) {
+		t.Parallel()
+
+		info := &pvc.Info{Claim: &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"volume.beta.kubernetes.io/storage-provisioner": "k8s.io/minikube-hostpath",
+			}},
+		}}
+
+		provisioner, err := info.Provisioner(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "k8s.io/minikube-hostpath", provisioner)
+	})
+
+	t.Run("falls back to the storage class provisioner when not yet bound", func(t *testing.T) {
+		t.Parallel()
+
+		storageClassName := "local-path"
+		storageClass := &storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: storageClassName},
+			Provisioner: "rancher.io/local-path",
+		}
+		info := &pvc.Info{
+			ClusterClient: &k8s.ClusterClient{KubeClient: fake.NewClientset(storageClass)},
+			Claim: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{StorageClassName: &storageClassName},
+			},
+		}
+
+		provisioner, err := info.Provisioner(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "rancher.io/local-path", provisioner)
+	})
+
+	t.Run("returns empty when neither annotation nor storage class is set", func(t *testing.T) {
+		t.Parallel()
+
+		info := &pvc.Info{Claim: &corev1.PersistentVolumeClaim{}}
+
+		provisioner, err := info.Provisioner(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, provisioner)
+	})
+
+	t.Run("returns an error when the storage class lookup fails", func(t *testing.T) {
+		t.Parallel()
+
+		storageClassName := "missing"
+		info := &pvc.Info{
+			ClusterClient: &k8s.ClusterClient{KubeClient: fake.NewClientset()},
+			Claim: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{StorageClassName: &storageClassName},
+			},
+		}
+
+		provisioner, err := info.Provisioner(t.Context())
+		require.Error(t, err)
+		assert.Empty(t, provisioner)
+	})
+
+	t.Run("returns empty for nil receiver or nil claim", func(t *testing.T) {
+		t.Parallel()
+
+		var nilInfo *pvc.Info
+
+		provisioner, err := nilInfo.Provisioner(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, provisioner)
+
+		provisioner, err = (&pvc.Info{}).Provisioner(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, provisioner)
 	})
 }
 

--- a/pvmigrate/pvmigrate.go
+++ b/pvmigrate/pvmigrate.go
@@ -86,6 +86,7 @@ type Migration struct {
 
 	DeleteExtraneousFiles bool
 	IgnoreMounted         bool
+	IgnoreSizes           bool
 	NoChown               bool
 	Detach                bool
 	Push                  bool
@@ -223,6 +224,7 @@ func toInternalRequest(mig *Migration) *migration.Request {
 		},
 		DeleteExtraneousFiles: mig.DeleteExtraneousFiles,
 		IgnoreMounted:         mig.IgnoreMounted,
+		IgnoreSizes:           mig.IgnoreSizes,
 		NoChown:               mig.NoChown,
 		Detach:                mig.Detach,
 		Push:                  mig.Push,


### PR DESCRIPTION
## What

Adds a pre-flight size check to the `migrate` command. Before any strategy runs, pv-migrate now compares the storage size of the source and destination PVCs and aborts with a clear message if the destination is smaller than the source.

A new `--ignore-sizes` flag skips the check.

Fixes #244

## Why

Currently, migrating into a smaller destination PVC fails midway with a generic, unhelpful error once rsync runs out of space — potentially after hours of copying:

```
🔶 Migration failed with this strategy, will try with the remaining strategies
❌ Error: migration failed: all strategies failed for this migration
```

The user has no indication that the root cause is insufficient destination capacity.

## How

- `pvc.Info.Size()` resolves a PVC's storage size, preferring the actual bound capacity (`Status.Capacity`) and falling back to the requested capacity (`Spec.Resources.Requests`).
- A new pre-flight check in the migrator fails with a descriptive error naming both PVCs and their sizes when `dest < source`:
  ```
  destination PVC ns/dest (1Gi) is smaller than source PVC ns/src (2Gi):
  the migration would likely fail once the destination runs out of space.
  If you are sure the data fits, re-run with --ignore-sizes
  ```
- The check is **skipped** when a size is unknown, to avoid false positives.
- `--ignore-sizes` lets users bypass the check when they know the data fits (e.g. a large but mostly empty source PVC) — as suggested in the issue.

## Notes / trade-off

The check compares **provisioned capacity**, not actual used data, since used size isn't known before copying. This is intentionally conservative: a 100Gi source holding 10Gi of data will be rejected against a 50Gi destination. `--ignore-sizes` is the documented escape hatch for exactly that case.

## Testing

- Unit tests for `Size()` (actual capacity, requested fallback, zero) and for the migrator check (smaller / larger / `--ignore-sizes`).
- `go build`, `go vet`, `go test ./...`, `golangci-lint v2.11.4` (matches CI) — all green.
- `docs/cli-reference.md` regenerated.
