### PR TITLE
fix: ship the matching architecture binary in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
 COPY --from=alpine:3.24.1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-ARG TARGETPLATFORM=linux/amd64
+ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/pv-migrate /pv-migrate
 ENTRYPOINT ["/pv-migrate"]


### PR DESCRIPTION
## Problem

The multi-arch Docker images since `3.0.0` ship the **amd64 binary inside the `linux/arm64` and `linux/arm/v7` images**, so on those hosts the container crash-loops with `exec /pv-migrate: exec format error`. `2.2.1` and earlier are unaffected. Same class of bug as utkuozdemir/nvidia_gpu_exporter#418.

## Root cause

The `Dockerfile` declared `ARG TARGETPLATFORM=linux/amd64`. That explicit default **shadows** the value BuildKit injects per platform, so the arm builds also resolved `TARGETPLATFORM` to `linux/amd64` and copied `linux/amd64/pv-migrate`. This started with the `dockers_v2` switch in `3.0.0`. The manifest metadata is correct (it advertises arm64/arm), only the binary inside the layer is wrong.

## Fix

Drop the default (`ARG TARGETPLATFORM`), matching goreleaser's documented `dockers_v2` Dockerfile example. BuildKit then sets the real target platform for each architecture.

## Verification

Empirically confirmed against the **published** images (pulled per-platform, extracted `/pv-migrate`, ran `file`):

| version | linux/amd64 | linux/arm64 | linux/arm/v7 |
|---|---|---|---|
| v3.0.0 – v3.5.0 (incl. `latest`) | x86-64 ✅ | **x86-64 ❌** | **x86-64 ❌** |
| v2.2.1 / v2.0.0 (control) | — | ARM aarch64 ✅ | — |

Reproduced the bug and verified the fix with buildx using a goreleaser-style per-platform context layout:

| | linux/amd64 | linux/arm64 | linux/arm/v7 |
|---|---|---|---|
| old Dockerfile | amd64 | **amd64 ❌** | **amd64 ❌** |
| fixed Dockerfile | amd64 | arm64 ✅ | armv7 ✅ |

The affected published images (`3.0.0`–`3.5.0` and `latest`) will be republished separately, rebuilt from the original release archive binaries (only the arm images' binary changes).