### PR TITLE
feat: explain exactly why a migration failed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,11 @@ Some specifics that surprise people:
 - rsync prints no total, so the total is inferred by scaling the transferred count by the percentage. That multiplication is skipped when it would overflow, because an out-of-range float-to-int conversion is implementation-defined in Go and would otherwise give a different answer on each CI architecture.
 - rclone prints JSON and revises its total upward as it walks, so a stats line can legitimately show more transferred than total.
 - Both `FindLast` functions share one implementation in `internal/progresslog`. Keep it that way: the previous duplicate drifted and one copy went stale.
+- While a transfer is being followed, the progress logger owns the writer, and it retries an ended stream until it is cancelled.
+  Anything that wants to print to that writer has to cancel the tail and join the goroutine first, or it interleaves with the bar's redraws.
+  The same retry is why a data mover result that is being treated as a success must still reach the logger's completion signal rather than returning early: the goroutine would otherwise never finish.
+- A retried follow resumes at the log's tail instead of replaying it, the bar is created once per transfer rather than once per stream attempt, and updates that move the transferred count backward are dropped.
+  All three exist because a replayed log used to re-drive a fresh bar to completion on every retry, stranding a finished bar line each time with a nonsense transfer rate.
 
 ## The embedded chart
 
@@ -133,6 +138,9 @@ Two things follow:
 
 - The chart is not published for standalone use and is not versioned independently. Its in-repo version is a placeholder that the CLI overwrites with its own at load time.
 - Changing a template changes the binary, so chart edits are code changes and need the Go tests, not only `helm lint`.
+- The Job scripts decide the container's exit code, and the client reads it back and attaches the data mover's own documented meaning for it.
+  So the retry loops capture the code rather than collapsing it, a condition the script decides to treat as a success announces itself with a line the client scans for, and the interpretation tables live next to the command builders they describe.
+  These scripts are covered by rendering the chart in a Go test and running the script under a real shell with a stand-in data mover, with the retry values zeroed so nothing sleeps.
 
 The chart README is generated from the comments in `values.yaml` by helm-docs and CI fails if it is stale, so never edit it directly.
 `docs/cli-reference.md` is likewise generated, from the commands' own help output.

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -48,6 +48,9 @@ $ pv-migrate \
   --dest new-pvc
 ```
 
+If files are deleted from the source while the transfer is running, rsync skips them, the migration still succeeds, and a warning line names the condition.
+With `--dest-delete-extraneous-files`, the skipped files keep their existing copies on the destination, so re-run the migration or copy from a source that is not being written to.
+
 Use custom data mover images:
 
 ```bash

--- a/integration/backup_test.go
+++ b/integration/backup_test.go
@@ -22,6 +22,7 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/klog/v2"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/k8s"
 	"github.com/utkuozdemir/pv-migrate/pvmigrate"
 )
@@ -577,7 +578,7 @@ func runMinioVerifyJob(t *testing.T, infra *backupTestInfra, ns, cmd string) str
 
 	// Wait for job completion
 	err := k8s.WaitForJobCompletion(ctx, infra.cli.KubeClient, ns, job.Name,
-		false, os.Stderr, slogt.New(t))
+		false, false, console.Palette{}, os.Stderr, slogt.New(t))
 	require.NoError(t, err)
 
 	// Get logs from the job pod

--- a/internal/app/backup.go
+++ b/internal/app/backup.go
@@ -89,6 +89,8 @@ func runBackup(cmd *cobra.Command, backup *pvmigrate.Backup, logger *slog.Logger
 	ctx := cmd.Context()
 	backup.Writer = cmd.ErrOrStderr()
 	backup.Logger = logger
+	backup.StructuredLogs = structuredLogsRequested(cmd)
+	backup.ColorOutput = colorOutputWanted(cmd, backup.Writer)
 
 	if err := readGCSServiceAccountFile(cmd, &backup.GCSServiceAccountJSON); err != nil {
 		return err
@@ -152,6 +154,8 @@ func runRestore(cmd *cobra.Command, restore *pvmigrate.Restore, logger *slog.Log
 	ctx := cmd.Context()
 	restore.Writer = cmd.ErrOrStderr()
 	restore.Logger = logger
+	restore.StructuredLogs = structuredLogsRequested(cmd)
+	restore.ColorOutput = colorOutputWanted(cmd, restore.Writer)
 
 	if err := readGCSServiceAccountFile(cmd, &restore.GCSServiceAccountJSON); err != nil {
 		return err

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -368,6 +368,26 @@ func setMigrateCmdFlags(cmd *cobra.Command, options *Options, logLevels, logForm
 	return nil
 }
 
+// structuredLogsRequested reports whether this invocation logs machine-readable
+// records, in which case plain-text blocks would corrupt the stream they share.
+func structuredLogsRequested(cmd *cobra.Command) bool {
+	format, err := cmd.Flags().GetString(FlagLogFormat)
+
+	return err == nil && format == logFormatJSON
+}
+
+// colorOutputWanted reports whether the plain-text blocks written to the given
+// writer should be colored: a terminal on the other end, no structured stream.
+func colorOutputWanted(cmd *cobra.Command, writer io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+
+	file, ok := writer.(*os.File)
+
+	return ok && isatty.IsTerminal(file.Fd()) && !structuredLogsRequested(cmd)
+}
+
 func runMigration(cmd *cobra.Command, options *Options, writer io.Writer, logger *slog.Logger) error {
 	ctx := cmd.Context()
 
@@ -375,6 +395,8 @@ func runMigration(cmd *cobra.Command, options *Options, writer io.Writer, logger
 	options.Migration.KeyAlgorithm = pvmigrate.KeyAlgorithm(options.keyAlgorithm)
 	options.Migration.Writer = writer
 	options.Migration.Logger = logger
+	options.Migration.StructuredLogs = options.LogFormat == logFormatJSON
+	options.Migration.ColorOutput = colorOutputWanted(cmd, writer)
 
 	logger.Info("🚀 Starting migration")
 
@@ -382,11 +404,9 @@ func runMigration(cmd *cobra.Command, options *Options, writer io.Writer, logger
 		logger.Info("❕ Extraneous files will be deleted from the destination")
 	}
 
-	if err := pvmigrate.Run(ctx, options.Migration); err != nil {
-		return fmt.Errorf("migration failed: %w", err)
-	}
-
-	return nil
+	// The public API already prefixes the error with "migration failed"; wrapping
+	// it again here only doubled the prefix in the one line the user reads.
+	return pvmigrate.Run(ctx, options.Migration)
 }
 
 func buildLogger(logLevel, logFormat string, writer io.Writer, isATTY bool) (*slog.Logger, error) {
@@ -405,7 +425,7 @@ func buildLogger(logLevel, logFormat string, writer io.Writer, isATTY bool) (*sl
 	case logFormatText:
 		handler = tint.NewTextHandler(writer, &tint.Options{
 			Level:   level,
-			NoColor: !isATTY,
+			NoColor: !isATTY || os.Getenv("NO_COLOR") != "",
 		})
 	default:
 		return nil, fmt.Errorf("unknown log format: %s", logFormat)

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -7,14 +7,17 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/jobprogress"
 	"github.com/utkuozdemir/pv-migrate/internal/k8s"
 	"github.com/utkuozdemir/pv-migrate/internal/opid"
@@ -37,7 +40,8 @@ func buildStatusCmd(logger **slog.Logger) *cobra.Command {
 				return errors.New("operation ID must not be empty")
 			}
 
-			return runStatus(cmd.Context(), *logger, kubeconfig, kubeContext, namespace, args[0], follow)
+			return runStatus(cmd.Context(), *logger, kubeconfig, kubeContext, namespace, args[0], follow,
+				structuredLogsRequested(cmd))
 		},
 	}
 
@@ -51,7 +55,8 @@ func buildStatusCmd(logger **slog.Logger) *cobra.Command {
 }
 
 func runStatus(
-	ctx context.Context, logger *slog.Logger, kubeconfig, kubeContext, namespace, operationID string, follow bool,
+	ctx context.Context, logger *slog.Logger, kubeconfig, kubeContext, namespace, operationID string,
+	follow, structuredLogs bool,
 ) error {
 	client, err := k8s.GetClusterClient(kubeconfig, kubeContext, logger)
 	if err != nil {
@@ -71,18 +76,9 @@ func runStatus(
 	}
 
 	if follow {
-		if job.Status.Succeeded > 0 || job.Status.Failed > 0 {
-			k8s.WriteRecentJobPodLogs(ctx, client.KubeClient, job, os.Stderr, logger)
-			printJobStatus(job, logger)
-
-			if job.Status.Failed > 0 {
-				return fmt.Errorf("failed to follow progress: job %s/%s failed", job.Namespace, job.Name)
-			}
-
-			return nil
-		}
-
-		err = followJobProgress(ctx, client.KubeClient, job, logger)
+		// No special case for an already-finished job: the waiter handles a
+		// terminal pod, and it is the only path that explains the exit code.
+		err = followJobProgress(ctx, client.KubeClient, job, structuredLogs, logger)
 		job = refreshJob(ctx, client.KubeClient, job, logger)
 		printJobStatus(job, logger)
 
@@ -93,15 +89,50 @@ func runStatus(
 		printJobProgress(ctx, client.KubeClient, job, logger)
 	}
 
+	// A failed operation is why status gets run at all, so the one-line status
+	// alone would bury the answer the pod still holds. The status line leads, so
+	// the evidence below it has context, then the explanation closes, and the
+	// exit code is non-zero so automation sees the failure too.
+	if job.Status.Failed > 0 {
+		printJobStatus(job, logger)
+
+		palette := console.Palette{Enabled: console.ForTerminal(isatty.IsTerminal(os.Stderr.Fd()), structuredLogs)}
+		explanation := k8s.DescribeJobFailure(ctx, client.KubeClient, job)
+
+		// The migration summary's shape: the verdict with its cause first, the
+		// evidence below it. In structured mode the explanation travels as a
+		// record instead, and the evidence follows the same rule.
+		if structuredLogs {
+			if explanation != "" {
+				logger.Error("❌ Operation failed", "error", explanation)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "\n%s\n", palette.Failure("Operation failed."))
+
+			for line := range strings.SplitSeq(explanation, "\n") {
+				fmt.Fprintf(os.Stderr, "    %s\n", line)
+			}
+		}
+
+		k8s.WriteJobFailureEvidence(ctx, client.KubeClient, job, structuredLogs, palette, os.Stderr, logger)
+
+		return fmt.Errorf("operation %s failed", operationID)
+	}
+
 	printJobStatus(job, logger)
 
 	return nil
 }
 
-func followJobProgress(ctx context.Context, cli kubernetes.Interface, job *batchv1.Job, logger *slog.Logger) error {
+func followJobProgress(
+	ctx context.Context, cli kubernetes.Interface, job *batchv1.Job, structuredLogs bool, logger *slog.Logger,
+) error {
 	logger.Info("Following job progress", "job", job.Name, "type", jobprogress.Description(job.Name))
 
-	if err := k8s.WaitForJobCompletion(ctx, cli, job.Namespace, job.Name, true, os.Stderr, logger); err != nil {
+	palette := console.Palette{Enabled: console.ForTerminal(isatty.IsTerminal(os.Stderr.Fd()), structuredLogs)}
+
+	if err := k8s.WaitForJobCompletion(ctx, cli, job.Namespace, job.Name, true, structuredLogs,
+		palette, os.Stderr, logger); err != nil {
 		return fmt.Errorf("failed to follow progress: %w", err)
 	}
 
@@ -166,23 +197,53 @@ func printJobStatus(job *batchv1.Job, logger *slog.Logger) {
 		status = "Pending"
 	}
 
-	var elapsed string
+	elapsed := jobElapsed(job)
 
-	if job.Status.StartTime != nil {
-		end := time.Now()
-		if job.Status.CompletionTime != nil {
-			end = job.Status.CompletionTime.Time
-		}
+	// The level carries the state: a failed operation announced at a green INFO
+	// reads as fine on a skim.
+	logFn := logger.Info
 
-		elapsed = end.Sub(job.Status.StartTime.Time).Truncate(time.Second).String()
+	switch {
+	case job.Status.Failed > 0:
+		logFn = logger.Error
+	case job.Status.Succeeded == 0 && job.Status.Active == 0:
+		logFn = logger.Warn
 	}
 
-	logger.Info("Operation status",
+	logFn("Operation status",
 		"job", job.Name,
 		"namespace", job.Namespace,
 		"status", status,
 		"elapsed", elapsed,
 	)
+}
+
+// jobElapsed reports how long the job ran. A failed job has no completion
+// time, and "now minus start" on one that failed days ago reads as a days-long
+// run, so the failure condition's transition time is the end when it is there.
+func jobElapsed(job *batchv1.Job) string {
+	if job.Status.StartTime == nil {
+		return ""
+	}
+
+	end := time.Now()
+
+	switch {
+	case job.Status.CompletionTime != nil:
+		end = job.Status.CompletionTime.Time
+	case job.Status.Failed > 0:
+		for i := range job.Status.Conditions {
+			cond := &job.Status.Conditions[i]
+			if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue &&
+				!cond.LastTransitionTime.IsZero() {
+				end = cond.LastTransitionTime.Time
+
+				break
+			}
+		}
+	}
+
+	return end.Sub(job.Status.StartTime.Time).Truncate(time.Second).String()
 }
 
 func formatBytes(bytes int64) string {

--- a/internal/bucketstorage/bucketstorage.go
+++ b/internal/bucketstorage/bucketstorage.go
@@ -1,6 +1,7 @@
 package bucketstorage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -21,7 +22,9 @@ import (
 	"helm.sh/helm/v4/pkg/cli/values"
 	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/client-go/kubernetes"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/helm"
 	"github.com/utkuozdemir/pv-migrate/internal/k8s"
 	"github.com/utkuozdemir/pv-migrate/internal/opid"
@@ -85,6 +88,15 @@ type Request struct {
 
 	Writer io.Writer
 	Logger *slog.Logger
+
+	// StructuredLogs reports that the logger writes machine-readable records to
+	// the same stream as Writer. Plain-text blocks are suppressed then, and the
+	// same information is emitted as log records instead.
+	StructuredLogs bool
+
+	// ColorOutput colors the plain-text report blocks semantically. Set only
+	// when the writer is a terminal and the logs are not machine-readable.
+	ColorOutput bool
 }
 
 // Run executes a backup or restore operation.
@@ -92,6 +104,12 @@ type Request struct {
 //nolint:cyclop,funlen
 func Run(ctx context.Context, req *Request) error {
 	logger := req.Logger
+
+	// Only the public API defaults the writer, so a direct caller can leave it
+	// unset. Everything below writes to it without checking.
+	if req.Writer == nil {
+		req.Writer = io.Discard
+	}
 
 	operationID := req.ID
 	if operationID == "" {
@@ -179,6 +197,10 @@ func Run(ctx context.Context, req *Request) error {
 	logger.Info("📦 Installing Helm chart")
 
 	if err = installHelmChart(helmChart, pvcInfo, releaseName, helmVals, req, logger); err != nil {
+		// A timed-out install means resources that are stuck rather than absent,
+		// and this path runs no cleanup, so they are still there to be read.
+		writeFailure(ctx, req, client.KubeClient, ns, releaseName, err, logger)
+
 		return fmt.Errorf("failed to install helm chart: %w", err)
 	}
 
@@ -532,13 +554,69 @@ func handleJobCompletion(
 	}
 
 	if err := k8s.WaitForJobCompletion(ctx, kubeClient, namespace, jobName,
-		shouldShowProgressBar(req.Writer), req.Writer, logger); err != nil {
-		return fmt.Errorf("%s failed: %w", req.Direction, err)
+		shouldShowProgressBar(req.Writer), req.StructuredLogs,
+		console.Palette{Enabled: req.ColorOutput}, req.Writer, logger); err != nil {
+		// Before the deferred cleanup removes the resources this is about.
+		writeFailure(ctx, req, kubeClient, namespace, releaseName, err, logger)
+
+		// Deliberately unwrapped: the error already names the failed pod and the
+		// exit state, the public API adds the operation prefix, and a plumbing
+		// wrap in between would push the answer further right.
+		return err //nolint:wrapcheck
 	}
 
 	logger.Info("✅ Operation succeeded")
 
 	return nil
+}
+
+// writeFailure explains a failure the way the migration summary does: a heading,
+// the cause on an indented line beneath it, then what the cluster reported. On a
+// structured log stream the plain-text block would corrupt the records around
+// it, so it travels inside a record instead.
+func writeFailure(
+	ctx context.Context,
+	req *Request,
+	kubeClient kubernetes.Interface,
+	namespace, releaseName string,
+	cause error,
+	logger *slog.Logger,
+) {
+	if req.StructuredLogs {
+		var buf bytes.Buffer
+
+		k8s.WriteWorkloadDiagnostics(ctx, kubeClient, namespace,
+			k8s.InstanceLabelSelector(releaseName), console.Palette{}, &buf, logger)
+
+		logger.Error("❌ What the cluster reported", "release", releaseName,
+			"namespace", namespace, "diagnostics", buf.String())
+
+		return
+	}
+
+	palette := console.Palette{Enabled: req.ColorOutput}
+
+	fmt.Fprintf(req.Writer, "%s\n", palette.Failure(capitalizedDirection(req.Direction)+" failed."))
+
+	if cause != nil {
+		for line := range strings.SplitSeq(cause.Error(), "\n") {
+			fmt.Fprintf(req.Writer, "    %s\n", line)
+		}
+	}
+
+	fmt.Fprintf(req.Writer, "\n%s\n\n  %s (namespace %s):\n",
+		palette.Bold("What the cluster reported:"), releaseName, namespace)
+	k8s.WriteWorkloadDiagnostics(ctx, kubeClient, namespace,
+		k8s.InstanceLabelSelector(releaseName), palette, req.Writer, logger)
+	fmt.Fprintln(req.Writer)
+}
+
+func capitalizedDirection(direction string) string {
+	if direction == "" {
+		return "Operation"
+	}
+
+	return strings.ToUpper(direction[:1]) + direction[1:]
 }
 
 func cleanupRelease(pvcInfo *pvc.Info, releaseName string, timeout time.Duration) error {

--- a/internal/console/palette.go
+++ b/internal/console/palette.go
@@ -1,0 +1,52 @@
+// Package console colors the plain-text report blocks semantically. The
+// coloring is driven by what the code knows about a line at render time, a
+// failed phase or a warning event or a healthy replica count, never by
+// matching words in the text, so a pod named "failed-app" cannot trick it.
+package console
+
+import "os"
+
+// Palette renders semantic colors. The zero value renders plain text, which is
+// what non-terminal writers and structured log streams use, and what keeps
+// every existing plain-text assertion valid.
+type Palette struct {
+	Enabled bool
+}
+
+const reset = "\x1b[0m"
+
+// Failure marks the headline of a failure report. Bold red.
+func (p Palette) Failure(s string) string { return p.wrap("1;31", s) }
+
+// Bad marks a hard failure fact: a failed phase, a non-zero exit, a rejected
+// image pull. Red.
+func (p Palette) Bad(s string) string { return p.wrap("31", s) }
+
+// Warn marks something abnormal but not terminal: a warning event, a pending
+// phase, a declined strategy. Yellow.
+func (p Palette) Warn(s string) string { return p.wrap("33", s) }
+
+// Good marks a healthy fact, which by contrast makes the one abnormal line in
+// a block stand out. Green.
+func (p Palette) Good(s string) string { return p.wrap("32", s) }
+
+// Dim marks neutral framing and inventory: block headings' object names, the
+// tail's caption, facts that are neither good nor bad. Faint.
+func (p Palette) Dim(s string) string { return p.wrap("2", s) }
+
+// Bold marks a section heading.
+func (p Palette) Bold(s string) string { return p.wrap("1", s) }
+
+func (p Palette) wrap(code, s string) string {
+	if !p.Enabled || s == "" {
+		return s
+	}
+
+	return "\x1b[" + code + "m" + s + reset
+}
+
+// ForTerminal reports whether colored output makes sense: a terminal on the
+// other end, no machine-readable stream sharing it, and no NO_COLOR ask.
+func ForTerminal(isTerminal, structuredLogs bool) bool {
+	return isTerminal && !structuredLogs && os.Getenv("NO_COLOR") == ""
+}

--- a/internal/console/palette_test.go
+++ b/internal/console/palette_test.go
@@ -1,0 +1,46 @@
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+)
+
+func TestPaletteDisabledIsPlainText(t *testing.T) {
+	t.Parallel()
+
+	var palette console.Palette
+
+	assert.Equal(t, "x", palette.Failure("x"))
+	assert.Equal(t, "x", palette.Bad("x"))
+	assert.Equal(t, "x", palette.Warn("x"))
+	assert.Equal(t, "x", palette.Good("x"))
+	assert.Equal(t, "x", palette.Dim("x"))
+	assert.Equal(t, "x", palette.Bold("x"))
+}
+
+func TestPaletteEnabledWrapsAndResets(t *testing.T) {
+	t.Parallel()
+
+	palette := console.Palette{Enabled: true}
+
+	assert.Equal(t, "\x1b[31mx\x1b[0m", palette.Bad("x"))
+	assert.Equal(t, "\x1b[1;31mx\x1b[0m", palette.Failure("x"))
+	assert.Empty(t, palette.Bad(""), "coloring nothing must stay nothing")
+}
+
+func TestForTerminal(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+
+	assert.True(t, console.ForTerminal(true, false))
+	assert.False(t, console.ForTerminal(true, true), "colors inside a structured stream corrupt it")
+	assert.False(t, console.ForTerminal(false, false))
+}
+
+func TestForTerminalHonorsNoColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	assert.False(t, console.ForTerminal(true, false))
+}

--- a/internal/helm/pv-migrate/templates/rclone/job.yaml
+++ b/internal/helm/pv-migrate/templates/rclone/job.yaml
@@ -54,8 +54,12 @@ spec:
               failure="rclone job"
               while [ "$n" -le "$retries" ]
               do
-                {{ required ".Values.rclone.command is required!" .Values.rclone.command }} {{ .Values.rclone.extraArgs }} && rc=0 && break
+                set -x
+                {{ required ".Values.rclone.command is required!" .Values.rclone.command }} {{ .Values.rclone.extraArgs }}
+                { rc=$?; set +x; } 2>/dev/null
+                [ "$rc" -eq 0 ] && break
                 n=$((n+1))
+                [ "$n" -gt "$retries" ] && break
                 echo "rclone attempt $n/$attempts failed, waiting $period seconds before trying again"
                 sleep $period
               done
@@ -63,23 +67,29 @@ spec:
 
               if [ $rc -eq 0 ]; then
                 echo '{{ .Values.rclone.metadataBase64 }}' | base64 -d > /tmp/metadata.yaml
-                metadata_rc=1
                 n=0
                 while [ "$n" -le "$retries" ]
                 do
-                  rclone --config "$PV_MIGRATE_CONFIG_PATH" copyto /tmp/metadata.yaml "$PV_MIGRATE_METADATA_REMOTE_PATH" && metadata_rc=0 && break
+                  rclone --config "$PV_MIGRATE_CONFIG_PATH" copyto /tmp/metadata.yaml "$PV_MIGRATE_METADATA_REMOTE_PATH"
+                  metadata_rc=$?
+                  [ "$metadata_rc" -eq 0 ] && break
                   n=$((n+1))
+                  [ "$n" -gt "$retries" ] && break
                   echo "metadata upload attempt $n/$attempts failed, waiting $period seconds before trying again"
                   sleep $period
                 done
+                # The metadata object is how a restore finds this backup, so a backup
+                # without it is not a backup. Its failure becomes the job's failure.
                 if [ $metadata_rc -ne 0 ]; then
-                  echo "data synced OK, metadata upload failed after $retries retries"
+                  echo "data synced OK, but the metadata upload failed, so restore would not find this backup"
+                  failure="metadata upload"
+                  rc=$metadata_rc
                 fi
               fi
               {{- end }}
 
               if [ $rc -ne 0 ]; then
-                echo "$failure failed after $retries retries"
+                echo "$failure failed with exit code $rc"
               fi
               exit $rc
           {{- if .Values.rclone.metadataBase64 }}

--- a/internal/helm/pv-migrate/templates/rsync/job.yaml
+++ b/internal/helm/pv-migrate/templates/rsync/job.yaml
@@ -46,7 +46,6 @@ spec:
             - sh
             - -c
             - |
-              set -x
               export HOME=$(awk -F: -v uid="$(id -u)" '$3==uid{print $6}' /etc/passwd)
               n=0
               rc=1
@@ -57,19 +56,37 @@ spec:
               privateKeyFilename=$(basename "{{ .Values.rsync.privateKeyMountPath }}")
               mkdir -p "$HOME/.ssh"
               chmod 700 "$HOME/.ssh"
-              cp -v "{{ .Values.rsync.privateKeyMountPath }}" "$HOME/.ssh/"
+              cp "{{ .Values.rsync.privateKeyMountPath }}" "$HOME/.ssh/"
               chmod 400 "$HOME/.ssh/$privateKeyFilename"
               {{- end }}
               while [ "$n" -le "$retries" ]
               do
-                {{ required ".Values.rsync.command is required!" .Values.rsync.command }} {{ .Values.rsync.extraArgs }} && rc=0 && break
+                # Traced so the log shows the exact data mover invocation, and
+                # nothing else: a fully traced script buries the two lines of
+                # evidence a reader needs under its own bookkeeping.
+                set -x
+                {{ required ".Values.rsync.command is required!" .Values.rsync.command }} {{ .Values.rsync.extraArgs }}
+                { rc=$?; set +x; } 2>/dev/null
+                [ "$rc" -eq 0 ] && break
+                # Vanished source files are expected on a volume that is still being
+                # written to, and retrying cannot bring them back. The echoed line is
+                # what the client looks for to report the skipped files, since on a
+                # successful job it never sees the raw log.
+                if [ "$rc" -eq 24 ]; then
+                  echo "pv-migrate: some source files vanished during the transfer; treated as success"
+                  rc=0
+                  break
+                fi
+                # A usage error is deterministic, so retrying only burns the budget.
+                [ "$rc" -eq 1 ] && break
                 n=$((n+1))
+                [ "$n" -gt "$retries" ] && break
                 echo "rsync attempt $n/$attempts failed, waiting $period seconds before trying again"
                 sleep $period
               done
 
               if [ $rc -ne 0 ]; then
-                echo "rsync job failed after $retries retries"
+                echo "rsync job failed with exit code $rc"
               fi
               exit $rc
           securityContext:

--- a/internal/helm/script_test.go
+++ b/internal/helm/script_test.go
@@ -1,0 +1,231 @@
+package helm_test
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/pv-migrate/internal/rsync"
+)
+
+// The Job scripts decide what the container exits with, and they used to collapse
+// every failure into 1. The control flow is what these tests are about, so they
+// run the rendered script under a real shell with a stand-in data mover. Retries
+// are zeroed, since the chart defaults would otherwise walk eleven attempts with
+// a sleep between each.
+
+func rsyncScript(t *testing.T, command string, maxRetries int) string {
+	t.Helper()
+
+	return containerScript(t, render(t, map[string]any{
+		"rsync": map[string]any{
+			"enabled":            true,
+			"namespace":          "default",
+			"command":            command,
+			"maxRetries":         maxRetries,
+			"retryPeriodSeconds": 0,
+			"pvcMounts":          []any{map[string]any{"name": "pvc", "mountPath": "/source"}},
+		},
+	}), "rsync")
+}
+
+func rcloneScript(t *testing.T, values map[string]any) string {
+	t.Helper()
+
+	rclone := map[string]any{
+		"enabled":            true,
+		"namespace":          "default",
+		"maxRetries":         0,
+		"retryPeriodSeconds": 0,
+		"pvcMounts":          []any{map[string]any{"name": "pvc", "mountPath": "/data"}},
+	}
+
+	maps.Copy(rclone, values)
+
+	return containerScript(t, render(t, map[string]any{"rclone": rclone}), "rclone")
+}
+
+// runScript runs the script the way the container does and returns its exit code
+// along with everything it printed.
+func runScript(t *testing.T, script string, env ...string) (int, string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", script)
+
+	cmd.Env = append(os.Environ(), env...)
+
+	out, err := cmd.CombinedOutput()
+	t.Log(string(out))
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), string(out)
+	}
+
+	require.NoError(t, err)
+
+	return 0, string(out)
+}
+
+// exitingMover is a stand-in data mover that exits with the given code.
+func exitingMover(code int) string {
+	return fmt.Sprintf("sh -c 'exit %d'", code)
+}
+
+func TestRsyncScriptPreservesTheExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		moverCode int
+		wantCode  int
+	}{
+		"success":     {moverCode: 0, wantCode: 0},
+		"usage error": {moverCode: 1, wantCode: 1},
+		"partial":     {moverCode: 23, wantCode: 23},
+		"vanished":    {moverCode: 24, wantCode: 0},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			code, _ := runScript(t, rsyncScript(t, exitingMover(tt.moverCode), 0))
+			assert.Equal(t, tt.wantCode, code)
+		})
+	}
+}
+
+// TestRsyncScriptMarksVanishedFiles pins the marker the client scans for. Without
+// it, a run that skipped files would report a plain success.
+func TestRsyncScriptMarksVanishedFiles(t *testing.T) {
+	t.Parallel()
+
+	code, out := runScript(t, rsyncScript(t, exitingMover(24), 0))
+
+	assert.Equal(t, 0, code)
+	// The client constant, not a copied literal: this assertion is what keeps
+	// the template's wording and the client's scan from drifting apart.
+	assert.Contains(t, out, rsync.VanishedFilesMarker)
+}
+
+// TestRsyncScriptRetriesUntilItSucceeds pins the loop control flow that the exit
+// code capture rewrote.
+func TestRsyncScriptRetriesUntilItSucceeds(t *testing.T) {
+	t.Parallel()
+
+	counter := filepath.Join(t.TempDir(), "attempts")
+	mover := fmt.Sprintf("sh -c 'echo x >> %s; if [ $(wc -l < %s) -ge 2 ]; then exit 0; else exit 12; fi'",
+		counter, counter)
+
+	code, _ := runScript(t, rsyncScript(t, mover, 1))
+	assert.Equal(t, 0, code)
+	assert.Equal(t, 2, countLines(t, counter))
+}
+
+// TestRsyncScriptDoesNotRetryUsageErrors: a typo in the extra arguments is
+// deterministic, so retrying it only spends the budget before the user hears
+// anything.
+func TestRsyncScriptDoesNotRetryUsageErrors(t *testing.T) {
+	t.Parallel()
+
+	counter := filepath.Join(t.TempDir(), "attempts")
+	mover := fmt.Sprintf("sh -c 'echo x >> %s; exit 1'", counter)
+
+	code, _ := runScript(t, rsyncScript(t, mover, 3))
+	assert.Equal(t, 1, code)
+	assert.Equal(t, 1, countLines(t, counter))
+}
+
+func TestRcloneScriptPreservesTheExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		moverCode int
+		wantCode  int
+	}{
+		"success":     {moverCode: 0, wantCode: 0},
+		"usage error": {moverCode: 1, wantCode: 1},
+		"directory":   {moverCode: 3, wantCode: 3},
+		// 24 is an rsync code and means nothing here, so it is passed through.
+		"twenty four": {moverCode: 24, wantCode: 24},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			code, _ := runScript(t, rcloneScript(t, map[string]any{"command": exitingMover(tt.moverCode)}))
+			assert.Equal(t, tt.wantCode, code)
+		})
+	}
+}
+
+// TestRcloneScriptFailsWhenTheMetadataUploadFails: the metadata object is how a
+// restore finds a backup, so a backup without one is not a backup and the job may
+// not report success. The container exits with the upload's real code, not a
+// collapsed sentinel.
+func TestRcloneScriptFailsWhenTheMetadataUploadFails(t *testing.T) {
+	t.Parallel()
+
+	script := rcloneScript(t, map[string]any{
+		"command":            exitingMover(0),
+		"metadataBase64":     "dGVzdAo=",
+		"metadataRemotePath": "remote:bucket/backup.meta.yaml",
+	})
+
+	code, out := runScript(t, script, "PATH="+failingRcloneDir(t, 7)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	assert.Equal(t, 7, code, "the metadata upload's own exit code has to survive")
+	assert.Contains(t, out, "metadata upload failed with exit code 7")
+}
+
+// TestRcloneScriptRetriesUsageErrors pins that rclone, unlike rsync, retries an
+// exit 1: rclone was observed exiting 1 for a transient credentials failure, so
+// treating it as a deterministic usage error would drop the retry budget where
+// it is needed.
+func TestRcloneScriptRetriesUsageErrors(t *testing.T) {
+	t.Parallel()
+
+	counter := filepath.Join(t.TempDir(), "attempts")
+	mover := fmt.Sprintf("sh -c 'echo x >> %s; exit 1'", counter)
+
+	code, _ := runScript(t, rcloneScript(t, map[string]any{"command": mover, "maxRetries": 1}))
+	assert.Equal(t, 1, code)
+	assert.Equal(t, 2, countLines(t, counter))
+}
+
+// failingRcloneDir returns a directory holding an rclone that always fails with
+// the given code, to be put in front of PATH.
+func failingRcloneDir(t *testing.T, code int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\nexit %d\n", code)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rclone"), []byte(script), 0o755)) //nolint:gosec
+
+	return dir
+}
+
+func countLines(t *testing.T, path string) int {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	count := 0
+
+	for _, b := range data {
+		if b == '\n' {
+			count++
+		}
+	}
+
+	return count
+}

--- a/internal/k8s/diagnostics.go
+++ b/internal/k8s/diagnostics.go
@@ -1,0 +1,484 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+)
+
+const (
+	instanceLabel = "app.kubernetes.io/instance"
+
+	// diagnosticsTimeout bounds the whole block. This runs on the failure path of
+	// an operation that is already over, so it may not add a wait of its own.
+	diagnosticsTimeout = 15 * time.Second
+
+	// maxEventsPerObject caps what is printed per object. The no-truncation rule
+	// is right for an error message and wrong for an event list.
+	maxEventsPerObject = 3
+
+	// maxEventsList caps the namespace-wide fetch the per-object cap selects from.
+	maxEventsList = 500
+)
+
+// InstanceLabelSelector selects everything a Helm release created, through the
+// label the chart puts on every resource.
+func InstanceLabelSelector(release string) string {
+	return instanceLabel + "=" + release
+}
+
+// workloadFacts is what the cluster said about one object.
+type workloadFacts struct {
+	uid     types.UID
+	kind    string
+	name    string
+	title   string
+	details []string
+	// quiet marks a fact that repeats what its pods already say, kept only when
+	// nothing else tells the story. bareTitle is what to print then: counters
+	// that lag their own pod would read as a contradiction next to the event
+	// the row was kept for.
+	quiet     bool
+	bareTitle string
+}
+
+// WriteWorkloadDiagnostics writes what the cluster reports about the resources of
+// one Helm release: the workloads, their pods' container states, their services'
+// addresses, and the warning events attached to any of them. Every line is an
+// observation, none is a conclusion. It never fails the caller: a request that is
+// forbidden or times out drops only what it would have added.
+func WriteWorkloadDiagnostics(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	ns, labelSelector string,
+	palette console.Palette,
+	writer io.Writer,
+	logger *slog.Logger,
+) {
+	if cli == nil || writer == nil {
+		return
+	}
+
+	ctx, cancel := detachedContext(ctx)
+	defer cancel()
+
+	objects, listedAny := listWorkloads(ctx, cli, ns, labelSelector, palette, logger)
+
+	// An empty result is only the observation "nothing exists" when something
+	// was actually read. Refused or failed lists reported as absence would tell
+	// a user on a locked-down cluster that the release created nothing.
+	if !listedAny {
+		fmt.Fprintln(writer, "    "+palette.Warn("could not read the cluster's resources"))
+
+		return
+	}
+
+	if len(objects) == 0 {
+		fmt.Fprintln(writer, "    "+palette.Dim("no resources found"))
+
+		return
+	}
+
+	events := warningEventsByUID(ctx, cli, ns, logger)
+
+	// A job row saying "1 active" under its own freshly failed pod reads as a
+	// contradiction: the controller's counters lag the pod. The row earns its
+	// place only when it carries something its pods do not.
+	objects = dropShadowedQuietFacts(objects, events)
+
+	for _, object := range objects {
+		fmt.Fprintf(writer, "    %s\n", object.title)
+
+		for _, detail := range object.details {
+			fmt.Fprintf(writer, "      %s\n", detail)
+		}
+
+		for _, event := range events[object.uid] {
+			fmt.Fprintf(writer, "      %s\n", palette.Warn(event))
+		}
+	}
+}
+
+// detachedContext bounds the diagnostics work while surviving the parent's
+// cancellation: the failure being explained may be a stalled API server or an
+// interrupted run, and a cancelled parent must not mean no diagnostics at all.
+func detachedContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), diagnosticsTimeout)
+}
+
+// listWorkloads gathers each kind separately, so that one request being refused
+// drops only what it would have added. listedAny reports whether at least one
+// list call succeeded, which is what separates "nothing exists" from "could not
+// look".
+func listWorkloads(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	ns, labelSelector string,
+	palette console.Palette,
+	logger *slog.Logger,
+) ([]workloadFacts, bool) {
+	options := metav1.ListOptions{LabelSelector: labelSelector}
+
+	runtime, runtimeListed := listRuntimeWorkloads(ctx, cli, ns, options, palette, logger)
+	owners, ownersListed := listOwnerWorkloads(ctx, cli, ns, options, palette, logger)
+
+	return append(runtime, owners...), runtimeListed || ownersListed
+}
+
+func listRuntimeWorkloads(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	ns string,
+	options metav1.ListOptions,
+	palette console.Palette,
+	logger *slog.Logger,
+) ([]workloadFacts, bool) {
+	var (
+		facts  []workloadFacts
+		listed bool
+	)
+
+	if pods, err := cli.CoreV1().Pods(ns).List(ctx, options); err != nil {
+		logDiagnosticsError(logger, "pods", ns, err)
+	} else {
+		listed = true
+
+		for i := range pods.Items {
+			facts = append(facts, podFacts(&pods.Items[i], palette))
+		}
+	}
+
+	if services, err := cli.CoreV1().Services(ns).List(ctx, options); err != nil {
+		logDiagnosticsError(logger, "services", ns, err)
+	} else {
+		listed = true
+
+		for i := range services.Items {
+			facts = append(facts, serviceFacts(&services.Items[i], palette))
+		}
+	}
+
+	return facts, listed
+}
+
+// listOwnerWorkloads covers the objects that own the pods, because the failures
+// that produce no pod at all (admission, quota, a missing service account) are
+// reported as events on the Job or the ReplicaSet.
+func listOwnerWorkloads(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	ns string,
+	options metav1.ListOptions,
+	palette console.Palette,
+	logger *slog.Logger,
+) ([]workloadFacts, bool) {
+	var (
+		facts  []workloadFacts
+		listed bool
+	)
+
+	if jobs, err := cli.BatchV1().Jobs(ns).List(ctx, options); err != nil {
+		logDiagnosticsError(logger, "jobs", ns, err)
+	} else {
+		listed = true
+
+		for i := range jobs.Items {
+			facts = append(facts, jobFacts(&jobs.Items[i], palette))
+		}
+	}
+
+	if deployments, err := cli.AppsV1().Deployments(ns).List(ctx, options); err != nil {
+		logDiagnosticsError(logger, "deployments", ns, err)
+	} else {
+		listed = true
+
+		for i := range deployments.Items {
+			facts = append(facts, deploymentFacts(&deployments.Items[i], palette))
+		}
+	}
+
+	if replicaSets, err := cli.AppsV1().ReplicaSets(ns).List(ctx, options); err != nil {
+		logDiagnosticsError(logger, "replicasets", ns, err)
+	} else {
+		listed = true
+
+		for i := range replicaSets.Items {
+			facts = append(facts, replicaSetFacts(&replicaSets.Items[i], palette))
+		}
+	}
+
+	return facts, listed
+}
+
+func logDiagnosticsError(logger *slog.Logger, kind, ns string, err error) {
+	logger.Debug("failed to list resources for diagnostics", "kind", kind, "namespace", ns, "error", err)
+}
+
+func podFacts(pod *corev1.Pod, palette console.Palette) workloadFacts {
+	facts := workloadFacts{
+		uid:   pod.UID,
+		kind:  "pod",
+		name:  pod.Name,
+		title: fmt.Sprintf("pod %s: %s", pod.Name, colorPhase(pod.Status.Phase, palette)),
+	}
+
+	for i := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[i]
+
+		switch {
+		case status.State.Waiting != nil:
+			// Yellow, not red: waiting is by definition not terminal, and a
+			// routine ContainerCreating must not carry the strongest signal.
+			facts.details = append(facts.details, palette.Warn(
+				fmt.Sprintf("container %s waiting: %s", status.Name, describeWaiting(status.State.Waiting))))
+		case status.State.Terminated != nil:
+			line := fmt.Sprintf("container %s terminated: %s",
+				status.Name, describeTerminatedBriefly(status.State.Terminated))
+			if status.State.Terminated.ExitCode != 0 {
+				line = palette.Bad(line)
+			} else {
+				line = palette.Dim(line)
+			}
+
+			facts.details = append(facts.details, line)
+		}
+
+		// A container that is waiting to be restarted says nothing about why it
+		// stopped, so the previous run's exit is the only thing that does.
+		if status.State.Waiting != nil && status.LastTerminationState.Terminated != nil {
+			facts.details = append(facts.details, palette.Warn(
+				fmt.Sprintf("container %s previously terminated: %s",
+					status.Name, describeTerminatedBriefly(status.LastTerminationState.Terminated))))
+		}
+	}
+
+	return facts
+}
+
+// colorPhase colors a pod phase by what it means: terminal failure red,
+// still-pending yellow, healthy green.
+func colorPhase(phase corev1.PodPhase, palette console.Palette) string {
+	switch phase {
+	case corev1.PodFailed:
+		return palette.Bad(string(phase))
+	case corev1.PodPending, corev1.PodUnknown:
+		return palette.Warn(string(phase))
+	case corev1.PodRunning, corev1.PodSucceeded:
+		return palette.Good(string(phase))
+	default:
+		return string(phase)
+	}
+}
+
+func describeWaiting(waiting *corev1.ContainerStateWaiting) string {
+	if message := strings.TrimSpace(waiting.Message); message != "" {
+		return waiting.Reason + ": " + message
+	}
+
+	return waiting.Reason
+}
+
+func describeTerminatedBriefly(terminated *corev1.ContainerStateTerminated) string {
+	parts := []string{fmt.Sprintf("exit code %d", terminated.ExitCode)}
+
+	if terminated.Signal != 0 {
+		parts = append(parts, fmt.Sprintf("signal %d", terminated.Signal))
+	}
+
+	if terminated.Reason != "" && terminated.Reason != genericTerminationReason {
+		parts = append(parts, "reason: "+terminated.Reason)
+	}
+
+	if message := strings.TrimSpace(terminated.Message); message != "" {
+		parts = append(parts, "message: "+message)
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// serviceFacts reports the address, or the absence of one: a LoadBalancer that
+// never gets an ingress entry is the whole of the load balancer timeout class.
+func serviceFacts(service *corev1.Service, palette console.Palette) workloadFacts {
+	facts := workloadFacts{
+		uid:   service.UID,
+		kind:  "service",
+		name:  service.Name,
+		title: palette.Dim(fmt.Sprintf("service %s: %s", service.Name, service.Spec.Type)),
+	}
+
+	var addresses []string
+
+	for _, ingress := range service.Status.LoadBalancer.Ingress {
+		if ingress.IP != "" {
+			addresses = append(addresses, ingress.IP)
+		}
+
+		if ingress.Hostname != "" {
+			addresses = append(addresses, ingress.Hostname)
+		}
+	}
+
+	if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		if len(addresses) == 0 {
+			facts.details = append(facts.details, palette.Bad("no external address assigned"))
+		} else {
+			facts.details = append(facts.details, palette.Good("external address: "+strings.Join(addresses, ", ")))
+		}
+	}
+
+	return facts
+}
+
+func jobFacts(job *batchv1.Job, palette console.Palette) workloadFacts {
+	title := fmt.Sprintf("job %s: %d active, %d succeeded, %d failed",
+		job.Name, job.Status.Active, job.Status.Succeeded, job.Status.Failed)
+
+	switch {
+	case job.Status.Failed > 0:
+		title = palette.Bad(title)
+	case job.Status.Succeeded > 0:
+		title = palette.Good(title)
+	default:
+		title = palette.Dim(title)
+	}
+
+	return workloadFacts{
+		uid:       job.UID,
+		kind:      "job",
+		name:      job.Name,
+		title:     title,
+		quiet:     job.Status.Succeeded == 0 && job.Status.Failed == 0,
+		bareTitle: palette.Dim("job " + job.Name + ":"),
+	}
+}
+
+// dropShadowedQuietFacts removes owner rows that add nothing over the pods
+// below them and have no events of their own.
+func dropShadowedQuietFacts(facts []workloadFacts, events map[types.UID][]string) []workloadFacts {
+	kept := facts[:0]
+
+	for _, fact := range facts {
+		if fact.quiet && len(events[fact.uid]) == 0 && hasPodOfWorkload(facts, fact.name) {
+			continue
+		}
+
+		// Kept only for its events: print it without the lagging counters.
+		if fact.quiet && len(events[fact.uid]) > 0 && fact.bareTitle != "" {
+			fact.title = fact.bareTitle
+		}
+
+		kept = append(kept, fact)
+	}
+
+	return kept
+}
+
+func hasPodOfWorkload(facts []workloadFacts, workloadName string) bool {
+	for _, fact := range facts {
+		if fact.kind == "pod" && strings.HasPrefix(fact.name, workloadName+"-") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func deploymentFacts(deployment *appsv1.Deployment, palette console.Palette) workloadFacts {
+	return workloadFacts{
+		uid:  deployment.UID,
+		kind: "deployment",
+		name: deployment.Name,
+		title: colorReadiness(fmt.Sprintf("deployment %s: %d/%d ready",
+			deployment.Name, deployment.Status.ReadyReplicas, deployment.Status.Replicas),
+			deployment.Status.ReadyReplicas, deployment.Status.Replicas, palette),
+	}
+}
+
+func replicaSetFacts(replicaSet *appsv1.ReplicaSet, palette console.Palette) workloadFacts {
+	return workloadFacts{
+		uid:  replicaSet.UID,
+		kind: "replicaset",
+		name: replicaSet.Name,
+		title: colorReadiness(fmt.Sprintf("replicaset %s: %d/%d ready",
+			replicaSet.Name, replicaSet.Status.ReadyReplicas, replicaSet.Status.Replicas),
+			replicaSet.Status.ReadyReplicas, replicaSet.Status.Replicas, palette),
+	}
+}
+
+// colorReadiness colors an owner workload's readiness: short of desired yellow,
+// fully ready green, empty neutral.
+func colorReadiness(line string, ready, desired int32, palette console.Palette) string {
+	switch {
+	case desired > 0 && ready < desired:
+		return palette.Warn(line)
+	case desired > 0:
+		return palette.Good(line)
+	default:
+		return palette.Dim(line)
+	}
+}
+
+// warningEventsByUID makes one list per namespace and keys it by the UID of the
+// object each event is about. Matching by name would attribute an event to the
+// wrong object, since the chart's sshd Deployment and Service share a name.
+func warningEventsByUID(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	ns string,
+	logger *slog.Logger,
+) map[types.UID][]string {
+	list, err := cli.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+		FieldSelector: "type=Warning",
+		// A shared namespace can hold a lot of events, and this runs on a
+		// failure path that should not fetch more than it can ever print.
+		Limit: maxEventsList,
+	})
+	if err != nil {
+		logDiagnosticsError(logger, "events", ns, err)
+
+		return nil
+	}
+
+	byUID := make(map[types.UID][]string)
+
+	// Kept in list order, which is roughly oldest first: when an object has more
+	// warnings than the cap, the earliest ones are the closest to the root cause.
+	for i := range list.Items {
+		event := &list.Items[i]
+
+		uid := event.InvolvedObject.UID
+		if event.Type != corev1.EventTypeWarning || uid == "" || len(byUID[uid]) >= maxEventsPerObject {
+			continue
+		}
+
+		byUID[uid] = append(byUID[uid], formatEvent(event))
+	}
+
+	return byUID
+}
+
+// formatEvent uses the API's own repeat count rather than deduplicating by hand.
+// A leading "Error: " in the message is the kubelet's boilerplate, already
+// covered by the event being a warning, so it is trimmed rather than stuttered.
+func formatEvent(event *corev1.Event) string {
+	message := strings.TrimPrefix(strings.TrimSpace(event.Message), "Error: ")
+	line := fmt.Sprintf("warning %s: %s", event.Reason, message)
+
+	if event.Count > 1 {
+		line += fmt.Sprintf(" (x%d)", event.Count)
+	}
+
+	return line
+}

--- a/internal/k8s/diagnostics_internal_test.go
+++ b/internal/k8s/diagnostics_internal_test.go
@@ -1,0 +1,28 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetachedContextSurvivesParentCancellation pins the property the fake
+// clientset cannot: diagnostics run on the failure path, where the parent
+// context may already be over, and that must not mean no diagnostics at all.
+func TestDetachedContextSurvivesParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	parent, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	detached, detachedCancel := detachedContext(parent)
+	defer detachedCancel()
+
+	require.NoError(t, detached.Err(), "a cancelled parent must not cancel the diagnostics context")
+
+	deadline, ok := detached.Deadline()
+	assert.True(t, ok, "the diagnostics context has to bound its own work instead")
+	assert.False(t, deadline.IsZero())
+}

--- a/internal/k8s/diagnostics_test.go
+++ b/internal/k8s/diagnostics_test.go
@@ -1,0 +1,239 @@
+package k8s_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+	"github.com/utkuozdemir/pv-migrate/internal/k8s"
+)
+
+const (
+	diagNS      = "default"
+	diagRelease = "pv-migrate-abc12-src"
+)
+
+func diagLabels() map[string]string {
+	return map[string]string{"app.kubernetes.io/instance": diagRelease}
+}
+
+func warningEvent(reason, message string, involved *corev1.ObjectReference, count int32) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Namespace: diagNS, Name: reason + "-" + involved.Name},
+		Type:           corev1.EventTypeWarning,
+		Reason:         reason,
+		Message:        message,
+		Count:          count,
+		InvolvedObject: *involved,
+	}
+}
+
+func writeDiagnostics(ctx context.Context, t *testing.T, objects ...runtime.Object) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	k8s.WriteWorkloadDiagnostics(ctx, fake.NewClientset(objects...), diagNS,
+		k8s.InstanceLabelSelector(diagRelease), console.Palette{}, &buf, slog.New(slog.DiscardHandler))
+
+	return buf.String()
+}
+
+func TestWriteWorkloadDiagnostics_PendingPodWithSchedulingEvent(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: diagNS, Name: diagRelease + "-sshd-abc", Labels: diagLabels(), UID: types.UID("pod-uid"),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	out := writeDiagnostics(t.Context(), t, pod,
+		warningEvent("FailedScheduling", "0/1 nodes are available: 1 node(s) didn't match node selector.",
+			&corev1.ObjectReference{Kind: "Pod", Name: pod.Name, UID: pod.UID}, 3),
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Namespace: diagNS, Name: "normal"},
+			Type:           corev1.EventTypeNormal,
+			Reason:         "Scheduled",
+			Message:        "nothing to see here",
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: pod.Name, UID: pod.UID},
+		})
+
+	assert.Contains(t, out, "pod "+pod.Name+": Pending")
+	assert.Contains(t, out, "warning FailedScheduling: 0/1 nodes are available")
+	assert.Contains(t, out, "(x3)", "the API's own repeat count is used instead of hand-rolled dedup")
+	// The fake clientset ignores field selectors, so what this exercises is the
+	// in-code warning-type guard, not the server-side selector.
+	assert.NotContains(t, out, "nothing to see here", "only warnings are reported")
+}
+
+func TestWriteWorkloadDiagnostics_ImagePullBackOff(t *testing.T) {
+	t.Parallel()
+
+	out := writeDiagnostics(t.Context(), t, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: diagNS, Name: diagRelease + "-rsync-abc", Labels: diagLabels(), UID: types.UID("pod-uid"),
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "rsync",
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ImagePullBackOff",
+						Message: `Back-off pulling image "docker.io/library/nosuchimage:latest"`,
+					}},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+					},
+				},
+			},
+		},
+	})
+
+	assert.Contains(t, out, "container rsync waiting: ImagePullBackOff: Back-off pulling image")
+	assert.Contains(t, out, "container rsync previously terminated: exit code 1")
+	assert.NotContains(t, out, "reason: Error",
+		"the generic reason Kubernetes attaches to every non-zero exit says nothing")
+}
+
+// TestWriteWorkloadDiagnostics_ZeroPodsWithFailedCreate is the admission class:
+// PodSecurity, ResourceQuota and missing service accounts reject the pod before
+// it exists, so the only record is an event on the workload that tried.
+func TestWriteWorkloadDiagnostics_ZeroPodsWithFailedCreate(t *testing.T) {
+	t.Parallel()
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: diagNS, Name: diagRelease + "-rsync", Labels: diagLabels(), UID: types.UID("job-uid"),
+		},
+	}
+
+	out := writeDiagnostics(t.Context(), t, job,
+		warningEvent("FailedCreate", `pods "x" is forbidden: violates PodSecurity "restricted:latest"`,
+			&corev1.ObjectReference{Kind: "Job", Name: job.Name, UID: job.UID}, 1))
+
+	assert.Contains(t, out, "job "+job.Name+":")
+	assert.Contains(t, out, `warning FailedCreate: pods "x" is forbidden: violates PodSecurity`)
+	assert.NotContains(t, out, "(x", "a single occurrence carries no repeat count")
+}
+
+// TestWriteWorkloadDiagnostics_EventMatchedByUIDNotName pins the identity rule.
+// The chart's sshd Deployment and Service share a name, so a name-keyed event
+// would be attributed to the wrong object.
+func TestWriteWorkloadDiagnostics_EventMatchedByUIDNotName(t *testing.T) {
+	t.Parallel()
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: diagNS, Name: diagRelease + "-sshd", Labels: diagLabels(), UID: types.UID("service-uid"),
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+	}
+
+	out := writeDiagnostics(t.Context(), t, service,
+		warningEvent("FailedCreate", "this belongs to the deployment of the same name",
+			&corev1.ObjectReference{Kind: "Deployment", Name: service.Name, UID: types.UID("deployment-uid")}, 1))
+
+	assert.Contains(t, out, "service "+service.Name+": LoadBalancer")
+	assert.Contains(t, out, "no external address assigned")
+	assert.NotContains(t, out, "this belongs to the deployment of the same name")
+}
+
+func TestWriteWorkloadDiagnostics_LoadBalancerWithAddress(t *testing.T) {
+	t.Parallel()
+
+	out := writeDiagnostics(t.Context(), t, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: diagNS, Name: diagRelease + "-sshd", Labels: diagLabels(), UID: types.UID("service-uid"),
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}}},
+		},
+	})
+
+	assert.Contains(t, out, "external address: 10.0.0.1")
+}
+
+func TestWriteWorkloadDiagnostics_ReportsOwnerWorkloads(t *testing.T) {
+	t.Parallel()
+
+	out := writeDiagnostics(t.Context(), t,
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: diagNS, Name: diagRelease + "-sshd", Labels: diagLabels(), UID: types.UID("deployment-uid"),
+			},
+			Status: appsv1.DeploymentStatus{Replicas: 1},
+		},
+		&appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: diagNS,
+				Name:      diagRelease + "-sshd-1",
+				Labels:    diagLabels(),
+				UID:       types.UID("replicaset-uid"),
+			},
+			Status: appsv1.ReplicaSetStatus{Replicas: 1},
+		})
+
+	assert.Contains(t, out, "deployment "+diagRelease+"-sshd: 0/1 ready")
+	assert.Contains(t, out, "replicaset "+diagRelease+"-sshd-1: 0/1 ready")
+}
+
+// TestWriteWorkloadDiagnostics_CancelledParentContext is a smoke test only: the
+// fake clientset never reads the context, so it cannot prove the detachment.
+// The property itself is pinned by the internal test on the detached context.
+func TestWriteWorkloadDiagnostics_CancelledParentContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	out := writeDiagnostics(ctx, t, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: diagNS, Name: diagRelease + "-rsync-abc", Labels: diagLabels(), UID: types.UID("pod-uid"),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodFailed},
+	})
+
+	require.Contains(t, out, "pod "+diagRelease+"-rsync-abc: Failed")
+}
+
+func TestWriteWorkloadDiagnostics_NoResources(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "    no resources found\n", writeDiagnostics(t.Context(), t))
+}
+
+// TestWriteWorkloadDiagnostics_UnreadableCluster separates "nothing exists" from
+// "could not look": every list refused must not be reported as absence.
+func TestWriteWorkloadDiagnostics_UnreadableCluster(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientset()
+	cli.PrependReactor("list", "*", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+
+	var buf bytes.Buffer
+
+	k8s.WriteWorkloadDiagnostics(t.Context(), cli, diagNS,
+		k8s.InstanceLabelSelector(diagRelease), console.Palette{}, &buf, slog.New(slog.DiscardHandler))
+
+	assert.Equal(t, "    could not read the cluster's resources\n", buf.String())
+}

--- a/internal/k8s/exitcode.go
+++ b/internal/k8s/exitcode.go
@@ -1,0 +1,215 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+	"github.com/utkuozdemir/pv-migrate/internal/rclone"
+	"github.com/utkuozdemir/pv-migrate/internal/rsync"
+)
+
+// failedPodError explains a failed job pod with what the cluster reported and
+// nothing else: the container's terminated state when it is there, the pod's own
+// reason otherwise. The exit code is joined by the data mover's documented
+// meaning for it, which is a statement about the documentation rather than a
+// claim about what happened.
+func failedPodError(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	jobName string,
+	pod *corev1.Pod,
+) error {
+	terminated := terminatedContainerState(pod, jobName)
+
+	// A watch event can carry the failed phase one step ahead of the container
+	// status, so refetch once before giving up on the exit code.
+	if terminated == nil {
+		if fresh, err := cli.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err == nil {
+			pod = fresh
+			terminated = terminatedContainerState(pod, jobName)
+		}
+	}
+
+	// "pod", not "job": the name carries the generated suffix, and calling it a
+	// job sends whoever copies it into kubectl after an object that is not there.
+	if terminated == nil {
+		return fmt.Errorf("pod %s/%s failed%s", pod.Namespace, pod.Name, podStatusDetail(pod))
+	}
+
+	return fmt.Errorf("pod %s/%s failed: %s", pod.Namespace, pod.Name, describeTerminated(jobName, terminated))
+}
+
+// describeTerminated renders everything the terminated state carries. An
+// OOMKilled reason next to code 137 explains more than any table row does, so
+// nothing here replaces anything else. The one exception is the reason string
+// "Error", which Kubernetes attaches to any non-zero exit and which therefore
+// says nothing.
+func describeTerminated(jobName string, terminated *corev1.ContainerStateTerminated) string {
+	parts := []string{fmt.Sprintf("the data mover exited with code %d", terminated.ExitCode)}
+
+	if terminated.Signal != 0 {
+		parts = append(parts, fmt.Sprintf("killed by signal %d", terminated.Signal))
+	}
+
+	if terminated.Reason != "" && terminated.Reason != genericTerminationReason {
+		parts = append(parts, "reason: "+terminated.Reason)
+	}
+
+	if message := strings.TrimSpace(terminated.Message); message != "" {
+		parts = append(parts, "message: "+message)
+	}
+
+	joined := strings.Join(parts, ", ")
+
+	// Parenthesized rather than comma-joined, so the attribution reads as an
+	// aside to the observed fact instead of splicing into it.
+	if meaning := interpretExitCode(jobName, int(terminated.ExitCode)); meaning != "" {
+		joined += " (" + meaning + ")"
+	}
+
+	return joined
+}
+
+// genericTerminationReason is what Kubernetes sets for any non-zero exit.
+const genericTerminationReason = "Error"
+
+// podStatusDetail is what is left to say when no container ever terminated, which
+// is how an evicted or admission-rejected pod looks.
+func podStatusDetail(pod *corev1.Pod) string {
+	var parts []string
+
+	if pod.Status.Reason != "" {
+		parts = append(parts, "reason: "+pod.Status.Reason)
+	}
+
+	if message := strings.TrimSpace(pod.Status.Message); message != "" {
+		parts = append(parts, "message: "+message)
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return ": " + strings.Join(parts, ", ")
+}
+
+// terminatedContainerState returns the terminated state of the data mover's
+// container, selected by name rather than by position. Only a job whose data
+// mover cannot be named falls back to any terminated container: in a pod with
+// injected sidecars, another container's exit code presented as the data
+// mover's would be a fabricated cause.
+func terminatedContainerState(pod *corev1.Pod, jobName string) *corev1.ContainerStateTerminated {
+	name := dataMoverContainer(jobName)
+
+	if name != "" {
+		for i := range pod.Status.ContainerStatuses {
+			status := &pod.Status.ContainerStatuses[i]
+			if status.Name == name && status.State.Terminated != nil {
+				return status.State.Terminated
+			}
+		}
+
+		return nil
+	}
+
+	for i := range pod.Status.ContainerStatuses {
+		if terminated := pod.Status.ContainerStatuses[i].State.Terminated; terminated != nil {
+			return terminated
+		}
+	}
+
+	return nil
+}
+
+// DescribeJobFailure returns the explanation for a failed job's pod, or an
+// empty string when there is nothing more to say than the job status itself.
+func DescribeJobFailure(ctx context.Context, cli kubernetes.Interface, job *batchv1.Job) string {
+	pod, _, err := findTerminalJobPod(ctx, cli, job.Namespace, job.Name)
+	if err != nil || pod == nil || pod.Status.Phase != corev1.PodFailed {
+		return ""
+	}
+
+	return failedPodError(ctx, cli, job.Name, pod).Error()
+}
+
+// WriteJobFailureEvidence prints a failed job's evidence: the pod's log tail
+// and what the cluster reports about the release's resources. Best effort, for
+// the status command, whose detached operations are the primary consumers of a
+// failure explanation.
+func WriteJobFailureEvidence(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	job *batchv1.Job,
+	structuredLogs bool,
+	palette console.Palette,
+	writer io.Writer,
+	logger *slog.Logger,
+) {
+	if pod, _, err := findTerminalJobPod(ctx, cli, job.Namespace, job.Name); err == nil && pod != nil {
+		writeFailureTail(ctx, cli, job.Name, pod, structuredLogs, palette, writer, logger)
+	}
+
+	release := job.Name
+	for _, suffix := range jobSuffixes {
+		release = strings.TrimSuffix(release, suffix)
+	}
+
+	if structuredLogs {
+		var buf bytes.Buffer
+
+		WriteWorkloadDiagnostics(
+			ctx,
+			cli,
+			job.Namespace,
+			InstanceLabelSelector(release),
+			console.Palette{},
+			&buf,
+			logger,
+		)
+		logger.Error("❌ What the cluster reported", "release", release,
+			"namespace", job.Namespace, "diagnostics", buf.String())
+
+		return
+	}
+
+	fmt.Fprintf(writer, "%s\n\n  %s (namespace %s):\n",
+		palette.Bold("What the cluster reported:"), release, job.Namespace)
+	WriteWorkloadDiagnostics(ctx, cli, job.Namespace, InstanceLabelSelector(release), palette, writer, logger)
+	fmt.Fprintln(writer)
+}
+
+// dataMoverContainer is the container the chart names after the data mover it
+// runs, picked by the job-name suffix the same way the progress parser is.
+func dataMoverContainer(jobName string) string {
+	switch {
+	case strings.HasSuffix(jobName, rsyncJobSuffix):
+		return "rsync"
+	case strings.HasSuffix(jobName, rcloneJobSuffix):
+		return "rclone"
+	default:
+		return ""
+	}
+}
+
+// interpretExitCode returns the data mover's own documented meaning for an exit
+// status. The tables live next to what they describe.
+func interpretExitCode(jobName string, code int) string {
+	switch {
+	case strings.HasSuffix(jobName, rsyncJobSuffix):
+		return rsync.Interpret(code)
+	case strings.HasSuffix(jobName, rcloneJobSuffix):
+		return rclone.Interpret(code)
+	default:
+		return ""
+	}
+}

--- a/internal/k8s/job.go
+++ b/internal/k8s/job.go
@@ -2,11 +2,13 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"strings"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 	batchv1 "k8s.io/api/batch/v1"
@@ -14,8 +16,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/jobprogress"
 	"github.com/utkuozdemir/pv-migrate/internal/progresslog"
+	"github.com/utkuozdemir/pv-migrate/internal/rsync"
 )
 
 const jobLogTailLines = 100
@@ -42,8 +46,14 @@ func FindJobPod(ctx context.Context, cli kubernetes.Interface, job *batchv1.Job)
 	return nil, fmt.Errorf("no pods found for job %s", job.Name)
 }
 
-// jobSuffixes are the suffixes used by pv-migrate Helm chart job names.
-var jobSuffixes = []string{"-rsync", "-rclone"}
+// The suffixes the pv-migrate Helm chart gives its job names, which is also how
+// the data mover behind a job is identified.
+const (
+	rsyncJobSuffix  = "-rsync"
+	rcloneJobSuffix = "-rclone"
+)
+
+var jobSuffixes = []string{rsyncJobSuffix, rcloneJobSuffix}
 
 // FindDataMoverJob finds the data-mover job (rsync or rclone) for a migration by listing
 // all Helm-managed jobs and matching by the release name prefix plus a known suffix.
@@ -95,7 +105,7 @@ func WaitForJobStart(ctx context.Context, cli kubernetes.Interface,
 
 	logger.Info("⏳ Waiting for job pod to start", "job", name)
 
-	pod, err := WaitForPod(ctx, cli, ns, labelSelector)
+	pod, err := WaitForPod(ctx, cli, ns, labelSelector, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +113,11 @@ func WaitForJobStart(ctx context.Context, cli kubernetes.Interface,
 	switch pod.Status.Phase { //nolint:exhaustive
 	case corev1.PodRunning:
 		logger.Info("🏃 Job pod is running", "pod", pod.Name)
-	case corev1.PodSucceeded, corev1.PodFailed:
-		logger.Info("🏁 Job pod has already completed", "pod", pod.Name, "phase", pod.Status.Phase)
+	case corev1.PodSucceeded:
+		logger.Info("🏁 Job pod has already completed", "pod", pod.Name)
+	case corev1.PodFailed:
+		// Not "completed": on a skim that reads as success.
+		logger.Warn("🔶 Job pod already terminated with a failure", "pod", pod.Name)
 	default:
 		logger.Info("✅ Job pod has started", "pod", pod.Name, "phase", pod.Status.Phase)
 	}
@@ -112,68 +125,259 @@ func WaitForJobStart(ctx context.Context, cli kubernetes.Interface,
 	return pod, nil
 }
 
-// WaitForJobCompletion waits for the Kubernetes job to complete.
+// WaitForJobCompletion waits for the Kubernetes job to complete. With
+// structuredLogs set, everything that would be raw text on the writer travels
+// as log records instead, so a machine-readable stream stays machine-readable.
+//
+//nolint:funlen
 func WaitForJobCompletion(ctx context.Context, cli kubernetes.Interface,
-	ns, name string, showProgressBar bool, writer io.Writer, logger *slog.Logger,
+	ns, name string, showProgressBar, structuredLogs bool, palette console.Palette,
+	writer io.Writer, logger *slog.Logger,
 ) (retErr error) {
-	pod, terminal, err := findTerminalJobPod(ctx, cli, ns, name)
-	if err != nil {
+	if writer == nil {
+		writer = io.Discard
+	}
+
+	pod, handled, err := resolveRunningJobPod(ctx, cli, ns, name, structuredLogs, palette, writer, logger)
+	if handled {
 		return err
 	}
-
-	if terminal {
-		writeRecentPodLogs(ctx, cli, pod, writer, logger)
-
-		return ensurePodSucceeded(pod)
-	}
-
-	pod, err = WaitForJobStart(ctx, cli, ns, name, logger)
-	if err != nil {
-		return err
-	}
-
-	if pod.Status.Phase != corev1.PodRunning {
-		writeRecentPodLogs(ctx, cli, pod, writer, logger)
-
-		return ensurePodSucceeded(pod)
-	}
-
-	var eg errgroup.Group
-
-	defer func() {
-		retErr = errors.Join(retErr, eg.Wait())
-	}()
 
 	tailCtx, tailCancel := context.WithCancel(ctx)
 	defer tailCancel()
 
-	progressLogger := jobprogress.NewLogger(name, progresslog.LoggerOptions{
-		Writer:          writer,
-		ShowProgressBar: showProgressBar,
-		LogStreamFunc: func(ctx context.Context) (io.ReadCloser, error) {
-			return cli.CoreV1().Pods(ns).GetLogs(pod.Name,
-				&corev1.PodLogOptions{Follow: true}).Stream(ctx)
-		},
-	})
+	var (
+		eg      errgroup.Group
+		stopped bool
+		// The bar overwrites one unterminated line until Finish prints its
+		// newline; whoever stops the follower before that has to terminate it.
+		barOpen = showProgressBar
+		// The follower retries an ended stream, and a retried follow replays
+		// the whole log from the start, which would re-drive the progress bar
+		// to 100% once per retry. Progress lines are cumulative, so a resumed
+		// stream only needs the lines it has not seen. Only the follower's own
+		// goroutine calls this, so the counter needs no locking.
+		streamedOnce = false
+		progress     = jobprogress.NewLogger(name, progresslog.LoggerOptions{
+			Writer:          writer,
+			ShowProgressBar: showProgressBar,
+			LogStreamFunc: func(ctx context.Context) (io.ReadCloser, error) {
+				options := followLogOptions(streamedOnce)
+				streamedOnce = true
+
+				return cli.CoreV1().Pods(ns).GetLogs(pod.Name, options).Stream(ctx)
+			},
+		})
+	)
+
+	// stopFollower cancels the log tail and joins its goroutine. The follower
+	// retries an ended stream until it is cancelled, and it owns the writer
+	// until it has stopped, so nothing else may print before this returns. It
+	// reports its error once, to whoever stops it first.
+	stopFollower := func() error {
+		if stopped {
+			return nil
+		}
+
+		stopped = true
+
+		tailCancel()
+
+		followErr := eg.Wait()
+
+		if barOpen && progress.Rendered() {
+			fmt.Fprintln(writer)
+		}
+
+		return followErr
+	}
+
+	defer func() { retErr = errors.Join(retErr, stopFollower()) }()
 
 	eg.Go(func() error {
-		return progressLogger.Start(tailCtx, logger)
+		return progress.Start(tailCtx, logger)
 	})
 
-	phase, err := waitForPodTermination(ctx, cli, pod.Namespace, pod.Name)
+	// A new variable on purpose: the follower's stream closure above reads pod,
+	// and reassigning it here would race with a live goroutine.
+	finalPod, err := waitForPodTermination(ctx, cli, pod.Namespace, pod.Name)
 	if err != nil {
 		return err
 	}
 
-	if *phase != corev1.PodSucceeded {
-		return failedPodError(pod)
+	if finalPod.Status.Phase != corev1.PodSucceeded {
+		followerErr := stopFollower()
+
+		writeFailureTail(ctx, cli, name, finalPod, structuredLogs, palette, writer, logger)
+
+		return errors.Join(failedPodError(ctx, cli, name, finalPod), followerErr)
 	}
 
-	if err = progressLogger.MarkAsComplete(ctx); err != nil {
+	if err = progress.MarkAsComplete(ctx); err != nil {
 		return fmt.Errorf("failed to mark progress logger as complete: %w", err)
 	}
 
+	// The bar is finished explicitly below, once the follower has stopped, so
+	// the stop must not terminate the line first.
+	barOpen = false
+
+	// Join the follower before logging anything else; it owns the writer until
+	// it has fully stopped, and the warning below must not interleave with it.
+	if followerErr := stopFollower(); followerErr != nil {
+		return followerErr
+	}
+
+	progress.FinishBar(logger)
+
+	// The progress parser consumed the log, so the marker the job script prints
+	// for skipped files has to be fetched back to be seen at all.
+	warnIfSourceFilesVanished(recentPodLogs(ctx, cli, finalPod, logger), logger)
+
 	return nil
+}
+
+// followLogOptions returns the follow options for the job pod's log stream: the
+// whole log on the first open, only new lines on a retry, so a replay cannot
+// rewind and re-complete the progress state.
+func followLogOptions(alreadyStreamed bool) *corev1.PodLogOptions {
+	options := &corev1.PodLogOptions{Follow: true}
+
+	if alreadyStreamed {
+		tail := int64(0)
+		options.TailLines = &tail
+	}
+
+	return options
+}
+
+// resolveRunningJobPod resolves everything that can be answered without a log
+// follower: a pod that is already terminal, a finished job with no pods left,
+// or a fresh pod that died before running. It reports handled=true when the
+// wait is over, with the error to return; otherwise the returned pod is
+// running and ready to be followed.
+func resolveRunningJobPod(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	ns, name string,
+	structuredLogs bool,
+	palette console.Palette,
+	writer io.Writer,
+	logger *slog.Logger,
+) (*corev1.Pod, bool, error) {
+	pod, anyPods, err := findTerminalJobPod(ctx, cli, ns, name)
+	if err != nil {
+		return nil, true, err
+	}
+
+	if pod != nil {
+		return nil, true, finishTerminalPod(ctx, cli, name, pod, structuredLogs, palette, writer, logger)
+	}
+
+	if !anyPods {
+		// A finished job whose pods are gone (deleted mid-run, drained node, TTL
+		// cleanup) has nothing to wait for: waiting for a pod would block for the
+		// whole watch timeout and then explain nothing.
+		if done, jobErr := finishedJobWithoutPods(ctx, cli, ns, name); done {
+			return nil, true, jobErr
+		}
+	}
+
+	pod, err = WaitForJobStart(ctx, cli, ns, name, logger)
+	if err != nil {
+		return nil, true, err
+	}
+
+	if pod.Status.Phase != corev1.PodRunning {
+		return nil, true, finishTerminalPod(ctx, cli, name, pod, structuredLogs, palette, writer, logger)
+	}
+
+	return pod, false, nil
+}
+
+// finishedJobWithoutPods reports whether the job already finished with no pods
+// left to inspect, and the error to return for it. An unreadable job falls
+// through to the normal waiting path.
+func finishedJobWithoutPods(ctx context.Context, cli kubernetes.Interface, ns, name string) (bool, error) {
+	job, err := cli.BatchV1().Jobs(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return false, nil //nolint:nilerr // fall through to waiting for a pod
+	}
+
+	if job.Status.Succeeded > 0 {
+		return true, nil
+	}
+
+	if job.Status.Failed > 0 {
+		detail := ""
+
+		for i := range job.Status.Conditions {
+			cond := &job.Status.Conditions[i]
+			if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue && cond.Message != "" {
+				detail = ": " + cond.Message
+
+				break
+			}
+		}
+
+		return true, fmt.Errorf("job %s/%s failed and its pod is gone%s", ns, name, detail)
+	}
+
+	return false, nil
+}
+
+// finishTerminalPod handles a job pod that was already done when it was found.
+// There is no follower running here, so the log tail can go straight out.
+func finishTerminalPod(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	jobName string,
+	pod *corev1.Pod,
+	structuredLogs bool,
+	palette console.Palette,
+	writer io.Writer,
+	logger *slog.Logger,
+) error {
+	if pod.Status.Phase != corev1.PodSucceeded {
+		writeFailureTail(ctx, cli, jobName, pod, structuredLogs, palette, writer, logger)
+
+		return failedPodError(ctx, cli, jobName, pod)
+	}
+
+	tail := recentPodLogs(ctx, cli, pod, logger)
+	if !structuredLogs {
+		writeTail(pod, jobName, tail, palette, writer, logger)
+	}
+
+	warnIfSourceFilesVanished(tail, logger)
+
+	return nil
+}
+
+// writeFailureTail hands over the failed pod's last log lines. On a structured
+// stream the raw lines would corrupt the records around them, so they travel
+// inside a record instead of on the writer.
+func writeFailureTail(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	jobName string,
+	pod *corev1.Pod,
+	structuredLogs bool,
+	palette console.Palette,
+	writer io.Writer,
+	logger *slog.Logger,
+) {
+	tail := recentPodLogs(ctx, cli, pod, logger)
+	if tail == "" {
+		return
+	}
+
+	if structuredLogs {
+		logger.Warn("🗒 Last log lines of the failed job pod", "pod", pod.Namespace+"/"+pod.Name, "tail", tail)
+
+		return
+	}
+
+	writeTail(pod, jobName, tail, palette, writer, logger)
 }
 
 func findTerminalJobPod(
@@ -193,7 +397,7 @@ func findTerminalJobPod(
 	for idx := range pods.Items {
 		switch pods.Items[idx].Status.Phase { //nolint:exhaustive
 		case corev1.PodPending, corev1.PodRunning:
-			return nil, false, nil
+			return nil, true, nil
 		case corev1.PodSucceeded:
 			terminal = &pods.Items[idx]
 		case corev1.PodFailed:
@@ -203,46 +407,130 @@ func findTerminalJobPod(
 		}
 	}
 
-	return terminal, terminal != nil, nil
+	return terminal, len(pods.Items) > 0, nil
 }
 
-func ensurePodSucceeded(pod *corev1.Pod) error {
-	if pod.Status.Phase != corev1.PodSucceeded {
-		return failedPodError(pod)
+// warnIfSourceFilesVanished surfaces the marker as a single line. It matters most
+// with --delete, where the files rsync skipped keep their old copies on the
+// destination while the run reports success. The count comes from rsync's own
+// vanished-file lines in the tail, so it is observed, not inferred, and it can
+// be missing when those lines scrolled out of the tail.
+func warnIfSourceFilesVanished(tail string, logger *slog.Logger) {
+	if !strings.Contains(tail, rsync.VanishedFilesMarker) {
+		return
 	}
 
-	return nil
-}
+	const msg = "🔶 Completed with a warning: some source files vanished during the transfer and were skipped. " +
+		"Re-run the migration, or copy from a source that is not being written to"
 
-func failedPodError(pod *corev1.Pod) error {
-	return fmt.Errorf("job %s/%s failed", pod.Namespace, pod.Name)
-}
-
-// WriteRecentJobPodLogs writes a best-effort tail of logs from a pod owned by the job.
-func WriteRecentJobPodLogs(
-	ctx context.Context,
-	cli kubernetes.Interface,
-	job *batchv1.Job,
-	writer io.Writer,
-	logger *slog.Logger,
-) {
-	pod, err := FindJobPod(ctx, cli, job)
-	if err != nil {
-		logger.Debug("failed to find job pod for recent logs", "job", job.Namespace+"/"+job.Name, "error", err)
+	if count := strings.Count(tail, "file has vanished:"); count > 0 {
+		logger.Warn(msg, "vanished_files", count)
 
 		return
 	}
 
-	writeRecentPodLogs(ctx, cli, pod, writer, logger)
+	logger.Warn(msg)
 }
 
-func writeRecentPodLogs(
+// writeTail puts a fetched log tail on the writer as a labelled, indented
+// quotation, so a reader can tell where the tool stops talking and the pod's
+// own output starts.
+func writeTail(pod *corev1.Pod, jobName, tail string, palette console.Palette, writer io.Writer, logger *slog.Logger) {
+	if tail == "" || writer == nil {
+		return
+	}
+
+	var rendered strings.Builder
+
+	fmt.Fprintf(&rendered, "\n%s\n",
+		palette.Dim(fmt.Sprintf("Last log lines of pod %s/%s:", pod.Namespace, pod.Name)))
+
+	for line := range strings.SplitSeq(strings.TrimRight(renderTail(jobName, tail), "\n"), "\n") {
+		rendered.WriteString("  " + line + "\n")
+	}
+
+	rendered.WriteString("\n")
+
+	if _, err := io.WriteString(writer, rendered.String()); err != nil {
+		logger.Debug("failed to write terminal job pod logs", "pod", pod.Namespace+"/"+pod.Name, "error", err)
+	}
+}
+
+// renderTail makes a tail readable without dropping evidence. rclone writes
+// structured JSON records whose useful part is the level and message, so those
+// are extracted; then, for every mover, lines that repeat anywhere in the tail
+// are printed once with an explicit count, the same convention the event lines
+// use. Counting instead of dropping keeps the collapse lossless.
+func renderTail(jobName, tail string) string {
+	lines := strings.Split(strings.TrimRight(tail, "\n"), "\n")
+
+	if strings.HasSuffix(jobName, rcloneJobSuffix) {
+		mapRcloneRecords(lines)
+	}
+
+	counts := make(map[string]int, len(lines))
+	for _, line := range lines {
+		counts[line]++
+	}
+
+	out := make([]string, 0, len(lines))
+	seen := make(map[string]bool, len(lines))
+
+	for _, line := range lines {
+		if seen[line] {
+			continue
+		}
+
+		seen[line] = true
+
+		if repeat := counts[line]; repeat > 1 && strings.TrimSpace(line) != "" {
+			line += fmt.Sprintf(" (x%d)", repeat)
+		}
+
+		out = append(out, line)
+	}
+
+	return strings.Join(out, "\n") + "\n"
+}
+
+// mapRcloneRecords rewrites rclone's structured JSON records in place as
+// "level: message" lines; whatever does not parse is kept as it came.
+func mapRcloneRecords(lines []string) {
+	for idx, line := range lines {
+		var record struct {
+			Level string `json:"level"`
+			Msg   string `json:"msg"`
+		}
+
+		if err := json.Unmarshal([]byte(line), &record); err != nil || record.Msg == "" {
+			continue
+		}
+
+		if record.Level != "" {
+			lines[idx] = record.Level + ": " + record.Msg
+		} else {
+			lines[idx] = record.Msg
+		}
+	}
+}
+
+// podLogFetchTimeout bounds the evidence fetch on paths where the parent
+// context may already be over, which is often the very failure being explained.
+const podLogFetchTimeout = 10 * time.Second
+
+// recentPodLogs returns a bounded tail of the pod's log, or an empty string when
+// it cannot be read. The log is evidence, not something to fail over, and it is
+// fetched even when the parent context was cancelled, since a timeout is one of
+// the failures the tail is fetched to explain.
+func recentPodLogs(
 	ctx context.Context,
 	cli kubernetes.Interface,
 	pod *corev1.Pod,
-	writer io.Writer,
 	logger *slog.Logger,
-) {
+) string {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), podLogFetchTimeout)
+	defer cancel()
+
 	tailLines := int64(jobLogTailLines)
 
 	stream, err := cli.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name,
@@ -250,7 +538,7 @@ func writeRecentPodLogs(
 	if err != nil {
 		logger.Debug("failed to read terminal job pod logs", "pod", pod.Namespace+"/"+pod.Name, "error", err)
 
-		return
+		return ""
 	}
 
 	defer func() {
@@ -260,7 +548,16 @@ func writeRecentPodLogs(
 		}
 	}()
 
-	if _, err = io.Copy(writer, stream); err != nil {
-		logger.Debug("failed to write terminal job pod logs", "pod", pod.Namespace+"/"+pod.Name, "error", err)
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		logger.Debug("failed to read terminal job pod logs", "pod", pod.Namespace+"/"+pod.Name, "error", err)
+
+		return ""
 	}
+
+	// rsync redraws its progress line with bare carriage returns; normalized
+	// here so every consumer of the tail sees plain lines.
+	tail := strings.ReplaceAll(string(data), "\r\n", "\n")
+
+	return strings.ReplaceAll(tail, "\r", "\n")
 }

--- a/internal/k8s/job_internal_test.go
+++ b/internal/k8s/job_internal_test.go
@@ -1,0 +1,25 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFollowLogOptions pins the retry contract of the follow stream: a retried
+// follow must not replay the log from the start, because the replay re-drives
+// the progress bar to 100% once per retry and strands a completed bar line
+// each time.
+func TestFollowLogOptions(t *testing.T) {
+	t.Parallel()
+
+	first := followLogOptions(false)
+	assert.True(t, first.Follow)
+	assert.Nil(t, first.TailLines, "the first open reads the whole log")
+
+	retry := followLogOptions(true)
+	assert.True(t, retry.Follow)
+	require.NotNil(t, retry.TailLines, "a retry must resume at the tail")
+	assert.Zero(t, *retry.TailLines)
+}

--- a/internal/k8s/job_test.go
+++ b/internal/k8s/job_test.go
@@ -2,17 +2,24 @@ package k8s_test
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/k8s"
 )
 
@@ -130,7 +137,7 @@ func TestWaitForJobCompletion_PodAlreadySucceededDoesNotWatchTermination(t *test
 		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
 	})
 
-	err := k8s.WaitForJobCompletion(ctx, cli, "default", "test-rclone", false,
+	err := k8s.WaitForJobCompletion(ctx, cli, "default", "test-rclone", false, false, console.Palette{},
 		&bytes.Buffer{}, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
 
@@ -151,16 +158,276 @@ func TestWaitForJobCompletion_PodAlreadyFailedReturnsError(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"job-name": "test-rclone"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "rclone",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 3}},
+				},
+			},
+		},
 	})
 
-	err := k8s.WaitForJobCompletion(ctx, cli, "default", "test-rclone", false,
+	err := k8s.WaitForJobCompletion(ctx, cli, "default", "test-rclone", false, false, console.Palette{},
 		&bytes.Buffer{}, slog.New(slog.DiscardHandler))
-	require.ErrorContains(t, err, "job default/test-rclone-abc failed")
+	require.ErrorContains(t, err,
+		`pod default/test-rclone-abc failed: the data mover exited with code 3 `+
+			`(rclone documents this exit code as: Directory not found)`)
 
 	for _, action := range cli.Actions() {
 		assert.NotEqual(t, "watch", action.GetVerb(), "already-failed pod should not start a watch")
 	}
+}
+
+// TestWaitForJobCompletion_RendersTerminatedStateAdditively covers the states a
+// table row cannot explain: OOMKilled next to 137 says more than any exit code
+// meaning does, so nothing replaces anything else.
+func TestWaitForJobCompletion_RendersTerminatedStateAdditively(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientset()
+
+	createPod(t, cli, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rsync-abc",
+			Namespace: "default",
+			Labels:    map[string]string{"job-name": "test-rsync"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "sidecar", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				{
+					Name: "rsync",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Signal:   9,
+						Reason:   "OOMKilled",
+						Message:  " out of memory ",
+					}},
+				},
+			},
+		},
+	})
+
+	err := k8s.WaitForJobCompletion(t.Context(), cli, "default", "test-rsync", false, false, console.Palette{},
+		&bytes.Buffer{}, slog.New(slog.DiscardHandler))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "the data mover exited with code 137")
+	assert.Contains(t, err.Error(), "killed by signal 9")
+	assert.Contains(t, err.Error(), "reason: OOMKilled")
+	assert.Contains(t, err.Error(), "message: out of memory")
+}
+
+// TestWaitForJobCompletion_PodFailedWithoutContainerStatus is the evicted-pod
+// shape: nothing terminated, so the pod's own reason is all there is to say.
+func TestWaitForJobCompletion_PodFailedWithoutContainerStatus(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientset()
+
+	createPod(t, cli, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rsync-abc",
+			Namespace: "default",
+			Labels:    map[string]string{"job-name": "test-rsync"},
+		},
+		Status: corev1.PodStatus{
+			Phase:   corev1.PodFailed,
+			Reason:  "Evicted",
+			Message: "The node was low on resource: ephemeral-storage",
+		},
+	})
+
+	err := k8s.WaitForJobCompletion(t.Context(), cli, "default", "test-rsync", false, false, console.Palette{},
+		&bytes.Buffer{}, slog.New(slog.DiscardHandler))
+	require.ErrorContains(t, err, "pod default/test-rsync-abc failed: reason: Evicted")
+	assert.NotContains(t, err.Error(), "exited with code",
+		"an exit code that was never reported must not be invented")
+}
+
+// TestWaitForJobCompletion_RunningPodThatFails is the path where the progress
+// follower is still alive at the moment of failure. It pins both halves: the log
+// tail is printed, and it is printed after the follower has been joined, so it
+// cannot interleave with the progress bar's redraws on the same writer. The fake
+// clientset offers no way to synchronise on the follow stream being open, so the
+// transition below is timer-based and the interleaving half is best-effort here;
+// the ordering itself is enforced structurally (the tail is only written after
+// the errgroup is joined) and the shared-variable race is gone by construction.
+//
+//nolint:paralleltest // the feature gate below is process-wide
+func TestWaitForJobCompletion_RunningPodThatFails(t *testing.T) {
+	// Not parallel: the feature gate is process-wide. The streaming list the
+	// reflector prefers is not served by the fake clientset, and this is the only
+	// test here that watches anything.
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	cli := fake.NewClientset()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rsync-abc",
+			Namespace: "default",
+			Labels:    map[string]string{"job-name": "test-rsync"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	createPod(t, cli, pod)
+
+	writer := &syncWriter{}
+
+	failed := pod.DeepCopy()
+	failed.Status = corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name:  "rsync",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 23}},
+			},
+		},
+	}
+
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+
+		_, err := cli.CoreV1().Pods("default").UpdateStatus(context.Background(), failed, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+	}()
+
+	err := k8s.WaitForJobCompletion(t.Context(), cli, "default", "test-rsync", true, false, console.Palette{},
+		writer, slog.New(slog.DiscardHandler))
+	require.ErrorContains(t, err, "the data mover exited with code 23")
+	require.ErrorContains(t, err, `rsync documents this exit code as: Partial transfer due to error`)
+
+	out := writer.String()
+	assert.Contains(t, out, fakePodLogs, "the log tail is the most useful thing to show and was being dropped")
+	assert.True(t, strings.HasSuffix(strings.TrimRight(out, "\n"), fakePodLogs),
+		"nothing may reach the writer after the tail, or the progress bar interleaves with it")
+}
+
+// fakePodLogs is what the fake clientset serves for any pod log request.
+const fakePodLogs = "fake logs"
+
+// syncWriter serialises the writes the progress bar and the log tail both make.
+type syncWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.buf.Write(p) //nolint:wrapcheck
+}
+
+func (w *syncWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.buf.String()
+}
+
+// TestWaitForJobCompletion_FinishedJobWithoutPods: a failed job whose pod was
+// deleted (mid-run kill, node drain, TTL) must fail fast with what the job
+// still knows, not block on a watch for a pod that will never come.
+func TestWaitForJobCompletion_FinishedJobWithoutPods(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rsync", Namespace: "default"},
+		Status: batchv1.JobStatus{
+			Failed: 1,
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:    batchv1.JobFailed,
+					Status:  corev1.ConditionTrue,
+					Message: "Job has reached the specified backoff limit",
+				},
+			},
+		},
+	})
+
+	start := time.Now()
+
+	err := k8s.WaitForJobCompletion(t.Context(), cli, "default", "test-rsync", false, false, console.Palette{},
+		&bytes.Buffer{}, slog.New(slog.DiscardHandler))
+	require.ErrorContains(t, err, "job default/test-rsync failed and its pod is gone")
+	require.ErrorContains(t, err, "backoff limit")
+	assert.Less(t, time.Since(start), 30*time.Second, "must not wait out the pod watch timeout")
+}
+
+// TestWaitForJobCompletion_PodFailsBeforeRunning covers the pre-follower branch:
+// a pod that goes Pending straight to Failed is finished by the terminal-pod
+// path, with the same explanation as any other failure.
+func TestWaitForJobCompletion_PodFailsBeforeRunning(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientset()
+
+	createPod(t, cli, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rsync-abc",
+			Namespace: "default",
+			Labels:    map[string]string{"job-name": "test-rsync"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "rsync",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 11}},
+				},
+			},
+		},
+	})
+
+	writer := &bytes.Buffer{}
+
+	err := k8s.WaitForJobCompletion(t.Context(), cli, "default", "test-rsync", false, false, console.Palette{},
+		writer, slog.New(slog.DiscardHandler))
+	require.ErrorContains(t, err, `rsync documents this exit code as: Error in file I/O`)
+	assert.Contains(t, writer.String(), fakePodLogs)
+}
+
+// TestWaitForJobCompletion_StructuredLogsKeepTheWriterClean: with a structured
+// log stream, the raw tail on the writer would corrupt the records around it,
+// so it has to travel inside a record instead.
+func TestWaitForJobCompletion_StructuredLogsKeepTheWriterClean(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientset()
+
+	createPod(t, cli, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rsync-abc",
+			Namespace: "default",
+			Labels:    map[string]string{"job-name": "test-rsync"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "rsync",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 23}},
+				},
+			},
+		},
+	})
+
+	var (
+		writer  bytes.Buffer
+		records bytes.Buffer
+	)
+
+	err := k8s.WaitForJobCompletion(t.Context(), cli, "default", "test-rsync", false, true, console.Palette{},
+		&writer, slog.New(slog.NewJSONHandler(&records, nil)))
+	require.ErrorContains(t, err, "the data mover exited with code 23")
+
+	assert.Empty(t, writer.String(), "raw text on a structured stream corrupts it")
+	assert.Contains(t, records.String(), fakePodLogs, "the tail still has to reach the user")
 }
 
 //nolint:funlen

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 )
@@ -19,15 +22,65 @@ const (
 	podWatchTimeout = 2 * time.Minute
 )
 
-func WaitForPod(ctx context.Context, cli kubernetes.Interface, ns, labelSelector string) (*corev1.Pod, error) {
+func WaitForPod(
+	ctx context.Context, cli kubernetes.Interface, ns, labelSelector string, logger *slog.Logger,
+) (*corev1.Pod, error) {
 	var result *corev1.Pod
+
+	// The watch already delivers every pod update; narrating a container's
+	// waiting reason the moment it appears turns minutes of silence into an
+	// answer, using the same observation the failure block would print later.
+	lastWaiting := ""
 
 	resCli := cli.CoreV1().Pods(ns)
 
 	ctx, cancel := context.WithTimeout(ctx, podWatchTimeout)
 	defer cancel()
 
-	listWatch := &cache.ListWatch{
+	listWatch := podLabelListWatch(resCli, labelSelector)
+
+	condition := func(event watch.Event) (bool, error) {
+		res, ok := event.Object.(*corev1.Pod)
+		if !ok {
+			return false, fmt.Errorf(
+				"unexpected type while watching pods: ns: %s, labelSelector: %s",
+				ns,
+				labelSelector,
+			)
+		}
+
+		if waiting := describePodWaiting(res); waiting != "" && waiting != lastWaiting && logger != nil {
+			lastWaiting = waiting
+
+			logger.Warn("🔶 Pod is not starting yet", "pod", res.Name, "waiting", waiting)
+		}
+
+		if res.Status.Phase != corev1.PodPending {
+			result = res
+
+			return true, nil
+		}
+
+		return false, nil
+	}
+
+	if _, err := watchtools.UntilWithSync(ctx, listWatch, &corev1.Pod{}, nil, condition); err != nil {
+		// The bare watch error says "timed out waiting for the condition" and
+		// names neither the wait nor its budget.
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("timed out after %s waiting for a pod (selector %s) to start: %w",
+				podWatchTimeout, labelSelector, err)
+		}
+
+		return nil, fmt.Errorf("failed to wait for pod: %w", err)
+	}
+
+	return result, nil
+}
+
+// podLabelListWatch lists and watches pods by label selector.
+func podLabelListWatch(resCli clientcorev1.PodInterface, labelSelector string) *cache.ListWatch {
+	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			options.LabelSelector = labelSelector
 
@@ -49,35 +102,28 @@ func WaitForPod(ctx context.Context, cli kubernetes.Interface, ns, labelSelector
 			return resWatch, nil
 		},
 	}
-
-	if _, err := watchtools.UntilWithSync(ctx, listWatch, &corev1.Pod{}, nil,
-		func(event watch.Event) (bool, error) {
-			res, ok := event.Object.(*corev1.Pod)
-			if !ok {
-				return false, fmt.Errorf(
-					"unexpected type while watching pods: ns: %s, labelSelector: %s",
-					ns,
-					labelSelector,
-				)
-			}
-
-			phase := res.Status.Phase
-			if phase != corev1.PodPending {
-				result = res
-
-				return true, nil
-			}
-
-			return false, nil
-		}); err != nil {
-		return nil, fmt.Errorf("failed to wait for pod: %w", err)
-	}
-
-	return result, nil
 }
 
-func waitForPodTermination(ctx context.Context, cli kubernetes.Interface, ns, name string) (*corev1.PodPhase, error) {
-	var result *corev1.PodPhase
+// describePodWaiting summarizes why a pending pod's containers are waiting, or
+// returns an empty string when there is nothing to say yet.
+func describePodWaiting(pod *corev1.Pod) string {
+	var parts []string
+
+	for i := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[i]
+		if status.State.Waiting != nil && status.State.Waiting.Reason != "" {
+			parts = append(parts, status.Name+": "+describeWaiting(status.State.Waiting))
+		}
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// waitForPodTermination returns the pod as it looked when it left the Running
+// phase. The whole object rather than the phase, because whoever decided the pod
+// failed also needs the container's exit code from that same observation.
+func waitForPodTermination(ctx context.Context, cli kubernetes.Interface, ns, name string) (*corev1.Pod, error) {
+	var result *corev1.Pod
 
 	resCli := cli.CoreV1().Pods(ns)
 
@@ -87,9 +133,7 @@ func waitForPodTermination(ctx context.Context, cli kubernetes.Interface, ns, na
 	}
 
 	if pod.Status.Phase != corev1.PodRunning {
-		phase := pod.Status.Phase
-
-		return &phase, nil
+		return pod, nil
 	}
 
 	fieldSelector := fields.OneTermEqualSelector(metav1.ObjectNameField, name).String()
@@ -123,9 +167,8 @@ func waitForPodTermination(ctx context.Context, cli kubernetes.Interface, ns, na
 				return false, fmt.Errorf("unexpected type while watching pods: %s/%s", ns, name)
 			}
 
-			phase := res.Status.Phase
-			if phase != corev1.PodRunning {
-				result = &phase
+			if res.Status.Phase != corev1.PodRunning {
+				result = res
 
 				return true, nil
 			}

--- a/internal/migration/types.go
+++ b/internal/migration/types.go
@@ -47,6 +47,15 @@ type Request struct {
 	NonRoot               bool
 	RsyncExtraArgs        string
 	Writer                io.Writer
+
+	// StructuredLogs reports that the logger writes machine-readable records to
+	// the same stream as Writer. Plain-text blocks are suppressed then, and the
+	// same information is emitted as log records instead.
+	StructuredLogs bool
+
+	// ColorOutput colors the plain-text report blocks semantically. Set only
+	// when the writer is a terminal and the logs are not machine-readable.
+	ColorOutput bool
 }
 
 type Migration struct {
@@ -63,4 +72,20 @@ type Attempt struct {
 	Detached              bool
 
 	ReleaseNames []string
+
+	// DiagnosticTargets records where this attempt actually installed something.
+	// It is filled in at install time rather than reconstructed afterwards, so a
+	// failure is only ever explained with resources this attempt created.
+	DiagnosticTargets []DiagnosticTarget
+
+	// Diagnostics is what the cluster reported about the attempt's resources,
+	// collected on the failure path before cleanup removes them.
+	Diagnostics string
+}
+
+// DiagnosticTarget is one Helm release and the PVC whose cluster and namespace
+// it was installed into.
+type DiagnosticTarget struct {
+	Release string
+	Info    *pvc.Info
 }

--- a/internal/migrator/diagnostics.go
+++ b/internal/migrator/diagnostics.go
@@ -1,0 +1,66 @@
+package migrator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+	"github.com/utkuozdemir/pv-migrate/internal/k8s"
+	"github.com/utkuozdemir/pv-migrate/internal/migration"
+	"github.com/utkuozdemir/pv-migrate/internal/pvc"
+)
+
+// collectDiagnostics asks every cluster this attempt installed into what it has
+// to say about the resources it created. It runs while a migration is already
+// failing, so it is best effort throughout: whatever cannot be read is left out
+// rather than turned into a second error.
+func collectDiagnostics(ctx context.Context, attempt *migration.Attempt, logger *slog.Logger) string {
+	var buf bytes.Buffer
+
+	palette := console.Palette{Enabled: attempt.Migration.Request.ColorOutput}
+
+	for _, target := range attempt.DiagnosticTargets {
+		info := target.Info
+		if info == nil || info.Claim == nil || info.ClusterClient == nil || info.ClusterClient.KubeClient == nil {
+			continue
+		}
+
+		fmt.Fprintf(&buf, "  %s (%snamespace %s):\n", target.Release, sideLabel(attempt, info), info.Claim.Namespace)
+
+		k8s.WriteWorkloadDiagnostics(ctx, info.ClusterClient.KubeClient, info.Claim.Namespace,
+			k8s.InstanceLabelSelector(target.Release), palette, &buf, logger)
+	}
+
+	return buf.String()
+}
+
+// sideLabel names which side of the migration a diagnostic target belongs to,
+// but only when the two sides actually differ: two blocks distinguished by
+// nothing but a namespace make the reader do the mapping the tool already has.
+func sideLabel(attempt *migration.Attempt, info *pvc.Info) string {
+	mig := attempt.Migration
+	if mig == nil || !sidesDiffer(mig.SourceInfo, mig.DestInfo) {
+		return ""
+	}
+
+	switch info {
+	case mig.SourceInfo:
+		return "source side, "
+	case mig.DestInfo:
+		return "destination side, "
+	default:
+		return ""
+	}
+}
+
+func sidesDiffer(src, dst *pvc.Info) bool {
+	if src == nil || dst == nil || src.Claim == nil || dst.Claim == nil ||
+		src.ClusterClient == nil || dst.ClusterClient == nil {
+		return false
+	}
+
+	return src.Claim.Namespace != dst.Claim.Namespace ||
+		src.ClusterClient.RestConfig.Host != dst.ClusterClient.RestConfig.Host
+}

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 
@@ -40,6 +41,12 @@ func (m *Migrator) Run(ctx context.Context, request *migration.Request, logger *
 		return err
 	}
 
+	// Only the public API defaults the writer, so a direct caller can leave it
+	// unset. Everything below writes to it without checking.
+	if request.Writer == nil {
+		request.Writer = io.Discard
+	}
+
 	logger = logger.With("source", request.Source.Namespace+"/"+request.Source.Name,
 		"dest", request.Dest.Namespace+"/"+request.Dest.Name)
 
@@ -58,7 +65,9 @@ func (m *Migrator) Run(ctx context.Context, request *migration.Request, logger *
 	logger = logger.With("migration_id", migrationID)
 	logger.Info("🔄 Attempting migration", "strategies", strings.Join(strategies, ","))
 
-	for _, name := range strategies {
+	outcomes := make([]attemptOutcome, 0, len(strategies))
+
+	for strategyIndex, name := range strategies {
 		str := nameToStrategyMap[name]
 		releasePrefix := opid.ReleasePrefix + migrationID + "-" + name
 		attemptLogger := logger.With("strategy", name)
@@ -71,17 +80,16 @@ func (m *Migrator) Run(ctx context.Context, request *migration.Request, logger *
 		attemptLogger.Info("🚁 Attempt using strategy")
 
 		if attemptErr := runAttempt(ctx, str, attempt, attemptLogger); attemptErr != nil {
-			if errors.Is(attemptErr, strategy.ErrUnaccepted) {
-				attemptLogger.Info(
-					"🦊 This strategy cannot handle this migration, will try the next one",
-					"reason", attemptErr.Error(),
-				)
+			last := strategyIndex == len(strategies)-1
+			outcomes = append(outcomes,
+				recordFailedAttempt(name, attempt, attemptErr, last, request.StructuredLogs, attemptLogger))
 
-				continue
+			// An interrupted run must not walk the remaining rungs: each failed
+			// attempt would sweep diagnostics on a context that survives the
+			// cancellation, turning one Ctrl-C into a long goodbye.
+			if ctx.Err() != nil {
+				break
 			}
-
-			attemptLogger.Warn("🔶 Migration failed with this strategy, "+
-				"will try with the remaining strategies", "error", attemptErr)
 
 			continue
 		}
@@ -97,7 +105,51 @@ func (m *Migrator) Run(ctx context.Context, request *migration.Request, logger *
 		return nil
 	}
 
-	return errors.New("all strategies failed for this migration")
+	reportOutcomes(request, outcomes, logger)
+
+	return newLadderExhaustedError(outcomes)
+}
+
+// recordFailedAttempt logs the attempt as it happens, the way it always has, and
+// keeps what it needs to explain the attempt again once the ladder is exhausted.
+func recordFailedAttempt(
+	name string,
+	attempt *migration.Attempt,
+	attemptErr error,
+	last, structuredLogs bool,
+	logger *slog.Logger,
+) attemptOutcome {
+	if errors.Is(attemptErr, strategy.ErrUnaccepted) {
+		outcome := attemptOutcome{strategy: name, declined: true, err: attemptErr}
+
+		// The promise of a next attempt is only made when one exists, and the
+		// reason is the typed one, without the error sentinel's suffix.
+		msg := "🦊 This strategy cannot handle this migration"
+		if !last {
+			msg += ", will try the next one"
+		}
+
+		logger.Info(msg, "reason", outcome.message())
+
+		return outcome
+	}
+
+	msg := "🔶 Migration failed with this strategy"
+	if !last {
+		msg += ", will try with the remaining strategies"
+	}
+
+	// On the last rung the summary repeats the error three lines below, so in
+	// text mode the mid-run line skips the long attribute rather than showing
+	// the same sentence twice on one screen. Mid-ladder, and always on a
+	// structured stream, the attribute is the only timely record.
+	if last && !structuredLogs {
+		logger.Warn(msg)
+	} else {
+		logger.Warn(msg, "error", attemptErr)
+	}
+
+	return attemptOutcome{strategy: name, err: attemptErr, diagnostics: attempt.Diagnostics}
 }
 
 func runAttempt(
@@ -107,6 +159,12 @@ func runAttempt(
 	logger *slog.Logger,
 ) (runErr error) {
 	defer func() {
+		// A declined strategy installed nothing, so there is nothing to clean up
+		// and nothing worth announcing about it.
+		if len(attempt.ReleaseNames) == 0 {
+			return
+		}
+
 		if attempt.Migration.Request.NoCleanup || attempt.Detached {
 			logger.Info("🧹 Cleanup skipped")
 
@@ -126,7 +184,16 @@ func runAttempt(
 		}
 	}()
 
-	return str.Run(ctx, attempt, logger)
+	runErr = str.Run(ctx, attempt, logger)
+
+	// A decline never reached the cluster, so there is nothing to ask it about.
+	// Anything else is collected here, the one point that sees every strategy's
+	// failure while the attempt's resources still exist.
+	if runErr != nil && !errors.Is(runErr, strategy.ErrUnaccepted) {
+		attempt.Diagnostics = collectDiagnostics(ctx, attempt, logger)
+	}
+
+	return runErr
 }
 
 func printDetachMessage(request *migration.Request, migrationID, strategyName string, logger *slog.Logger) {

--- a/internal/migrator/outcome.go
+++ b/internal/migrator/outcome.go
@@ -1,0 +1,193 @@
+package migrator
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+	"github.com/utkuozdemir/pv-migrate/internal/migration"
+	"github.com/utkuozdemir/pv-migrate/internal/strategy"
+)
+
+const (
+	outcomeDeclined = "declined"
+	outcomeFailed   = "failed"
+)
+
+// attemptOutcome is what one rung of the ladder produced. The reasons are logged
+// as the ladder runs, but by the time it is exhausted they have scrolled past,
+// so they are kept here and reported again together.
+type attemptOutcome struct {
+	strategy    string
+	declined    bool
+	err         error
+	diagnostics string
+}
+
+func (o attemptOutcome) status() string {
+	if o.declined {
+		return outcomeDeclined
+	}
+
+	return outcomeFailed
+}
+
+// message is what to print for this outcome. A decline carries its reason as a
+// typed error, but a strategy is free to return a bare ErrUnaccepted with no
+// reason, and that has to render as its own text rather than as a blank row.
+func (o attemptOutcome) message() string {
+	var declined *strategy.DeclinedError
+	if errors.As(o.err, &declined) && declined.Reason != "" {
+		return declined.Reason
+	}
+
+	if o.err == nil {
+		return ""
+	}
+
+	return o.err.Error()
+}
+
+// ladderExhaustedError reports that every requested strategy declined or failed.
+// Its message stays one line, because the CLI renders it as a single log
+// attribute, and the per-strategy errors are reachable through the standard
+// unwrap tree instead.
+type ladderExhaustedError struct {
+	errs []error
+}
+
+func (e *ladderExhaustedError) Error() string {
+	return "no strategy could complete the migration"
+}
+
+func (e *ladderExhaustedError) Unwrap() []error {
+	return e.errs
+}
+
+func newLadderExhaustedError(outcomes []attemptOutcome) error {
+	errs := make([]error, 0, len(outcomes))
+
+	for _, outcome := range outcomes {
+		if outcome.err == nil {
+			continue
+		}
+
+		errs = append(errs, fmt.Errorf("%s: %w", outcome.strategy, outcome.err))
+	}
+
+	return &ladderExhaustedError{errs: errs}
+}
+
+// reportOutcomes explains the exhausted ladder. The summary is a plain-text block
+// on the request's writer, since packing it into the returned error would hand a
+// multi-line string to a log handler that renders it as one attribute. When the
+// logger writes JSON to that same stream, the block would corrupt it, so the
+// outcomes go out as log records instead.
+func reportOutcomes(request *migration.Request, outcomes []attemptOutcome, logger *slog.Logger) {
+	if request.StructuredLogs {
+		for _, outcome := range outcomes {
+			args := []any{"strategy", outcome.strategy, "outcome", outcome.status(), "error", outcome.message()}
+			if outcome.diagnostics != "" {
+				args = append(args, "diagnostics", outcome.diagnostics)
+			}
+
+			// A decline is not a failure by this project's own invariant, so it
+			// must not trip consumers filtering on the error level.
+			if outcome.declined {
+				logger.Warn("🦊 Strategy declined the migration", args...)
+
+				continue
+			}
+
+			logger.Error("❌ Strategy did not complete the migration", args...)
+		}
+
+		return
+	}
+
+	writeSummary(request.Writer, outcomes, console.Palette{Enabled: request.ColorOutput})
+}
+
+// writeSummary explains the exhausted ladder. Decline reasons are short and sit
+// in their row; failure messages are printed whole on their own indented lines,
+// since a long error chain inside a table cell defeats the table on any real
+// terminal width. A single-strategy run gets a sentence, because a one-row
+// table about "no strategy" reads as if several were tried.
+func writeSummary(writer io.Writer, outcomes []attemptOutcome, palette console.Palette) {
+	fmt.Fprintln(writer)
+
+	if len(outcomes) == 1 {
+		outcome := outcomes[0]
+
+		fmt.Fprintln(writer,
+			palette.Failure(fmt.Sprintf("Migration failed: the %s strategy %s.", outcome.strategy, outcome.status())))
+		writeIndented(writer, outcome.message())
+	} else {
+		nameWidth := 0
+		for _, outcome := range outcomes {
+			nameWidth = max(nameWidth, len(outcome.strategy))
+		}
+
+		fmt.Fprintln(writer, palette.Failure("Migration failed: no strategy could complete the migration."))
+		fmt.Fprintln(writer)
+
+		for _, outcome := range outcomes {
+			// The status word is padded before coloring: escape codes have
+			// width for the formatter but not for the terminal.
+			name := fmt.Sprintf("%-*s", nameWidth, outcome.strategy)
+
+			if outcome.declined {
+				fmt.Fprintf(
+					writer,
+					"  %s  %s  %s\n",
+					palette.Bold(name),
+					palette.Warn(outcomeDeclined),
+					outcome.message(),
+				)
+
+				continue
+			}
+
+			fmt.Fprintf(writer, "  %s  %s\n", palette.Bold(name), palette.Bad(outcomeFailed))
+			writeIndented(writer, outcome.message())
+		}
+	}
+
+	fmt.Fprintln(writer)
+
+	writeDiagnosticsBlocks(writer, outcomes, palette)
+}
+
+func writeIndented(writer io.Writer, message string) {
+	for line := range strings.SplitSeq(message, "\n") {
+		fmt.Fprintf(writer, "    %s\n", line)
+	}
+}
+
+// writeDiagnosticsBlocks prints what the cluster reported for the attempts that
+// got as far as creating something. Declines never reach the cluster.
+func writeDiagnosticsBlocks(writer io.Writer, outcomes []attemptOutcome, palette console.Palette) {
+	printed := false
+
+	for _, outcome := range outcomes {
+		if outcome.diagnostics == "" {
+			continue
+		}
+
+		if !printed {
+			fmt.Fprintln(writer, palette.Bold("What the cluster reported:"))
+			fmt.Fprintln(writer)
+
+			printed = true
+		}
+
+		fmt.Fprint(writer, outcome.diagnostics)
+	}
+
+	if printed {
+		fmt.Fprintln(writer)
+	}
+}

--- a/internal/migrator/outcome_test.go
+++ b/internal/migrator/outcome_test.go
@@ -1,0 +1,149 @@
+package migrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/neilotoole/slogt/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/pv-migrate/internal/migration"
+	"github.com/utkuozdemir/pv-migrate/internal/strategy"
+)
+
+func failingMigrator(errs map[string]error) Migrator {
+	strategies := make(map[string]strategy.Strategy, len(errs))
+
+	for name, err := range errs {
+		strategies[name] = &mockStrategy{
+			runFunc: func(context.Context, *migration.Attempt) error { return err },
+		}
+	}
+
+	return Migrator{
+		getKubeClient: fakeClusterClientGetter(),
+		getStrategyMap: func([]string) (map[string]strategy.Strategy, error) {
+			return strategies, nil
+		},
+	}
+}
+
+func TestRunSummarizesEveryOutcome(t *testing.T) {
+	t.Parallel()
+
+	failure := errors.New("failed to get service address: timed out after 2m0s")
+
+	mig := failingMigrator(map[string]error{
+		"mount":        strategy.Declined("source and destination are in different namespaces"),
+		"loadbalancer": failure,
+		"bare":         strategy.ErrUnaccepted,
+	})
+
+	var out bytes.Buffer
+
+	req := buildMigrationRequestWithStrategies([]string{"mount", "loadbalancer", "bare"}, true)
+	req.Writer = &out
+
+	err := mig.Run(t.Context(), req, slogt.New(t))
+	require.Error(t, err)
+
+	assert.Equal(t, "no strategy could complete the migration", err.Error(),
+		"the message is rendered as a single log attribute, so it stays one line")
+	require.ErrorIs(t, err, failure, "the per-strategy errors stay reachable through the unwrap tree")
+	require.ErrorIs(t, err, strategy.ErrUnaccepted)
+
+	summary := out.String()
+
+	assert.Contains(t, summary, "Migration failed: no strategy could complete the migration.")
+	assert.Contains(t, summary, "mount")
+	assert.Contains(t, summary, "declined")
+	assert.Contains(t, summary, "source and destination are in different namespaces")
+	assert.Contains(t, summary, "failed")
+	assert.Contains(t, summary, "failed to get service address: timed out after 2m0s")
+	assert.Contains(t, summary, "unaccepted",
+		"a decline with no reason must render its own text rather than a blank row")
+	assert.NotContains(t, summary, "clusterip", "only the requested strategies are listed")
+}
+
+func TestRunSummaryIndentsMultiLineFailures(t *testing.T) {
+	t.Parallel()
+
+	mig := failingMigrator(map[string]error{
+		"mount": errors.New("first line\nsecond line"),
+	})
+
+	var out bytes.Buffer
+
+	req := buildMigrationRequestWithStrategies([]string{"mount"}, true)
+	req.Writer = &out
+
+	require.Error(t, mig.Run(t.Context(), req, slogt.New(t)))
+	assert.Contains(t, out.String(), "Migration failed: the mount strategy failed.\n",
+		"a single-strategy run reads as a sentence, not a one-row table")
+	assert.Contains(t, out.String(), "\n    first line\n    second line\n",
+		"the failure text sits on its own indented lines, whole")
+}
+
+// TestRunSummaryColorsWhenRequested pins that the color plumbing reaches the
+// summary, and that it is off by default so every plain-text assertion above
+// stays exact.
+func TestRunSummaryColorsWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	mig := failingMigrator(map[string]error{"mount": errors.New("boom")})
+
+	var out bytes.Buffer
+
+	req := buildMigrationRequestWithStrategies([]string{"mount"}, true)
+	req.Writer = &out
+	req.ColorOutput = true
+
+	require.Error(t, mig.Run(t.Context(), req, slogt.New(t)))
+	assert.Contains(t, out.String(), "\x1b[1;31mMigration failed: the mount strategy failed.\x1b[0m")
+}
+
+func TestRunWithoutWriterDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	mig := failingMigrator(map[string]error{"mount": errors.New("boom")})
+
+	req := buildMigrationRequestWithStrategies([]string{"mount"}, true)
+	req.Writer = nil
+
+	require.Error(t, mig.Run(t.Context(), req, slogt.New(t)))
+}
+
+func TestRunPrintsNothingWhenAStrategySucceeds(t *testing.T) {
+	t.Parallel()
+
+	mig := failingMigrator(map[string]error{
+		"mount": strategy.Declined("source and destination are in different namespaces"),
+		"ok":    nil,
+	})
+
+	var out bytes.Buffer
+
+	req := buildMigrationRequestWithStrategies([]string{"mount", "ok"}, true)
+	req.Writer = &out
+
+	require.NoError(t, mig.Run(t.Context(), req, slogt.New(t)))
+	assert.Empty(t, out.String())
+}
+
+func TestRunSuppressesTheSummaryForStructuredLogs(t *testing.T) {
+	t.Parallel()
+
+	mig := failingMigrator(map[string]error{"mount": errors.New("boom")})
+
+	var out bytes.Buffer
+
+	req := buildMigrationRequestWithStrategies([]string{"mount"}, true)
+	req.Writer = &out
+	req.StructuredLogs = true
+
+	require.Error(t, mig.Run(t.Context(), req, slogt.New(t)))
+	assert.Empty(t, out.String(), "a plain-text block would corrupt the JSON records on the same stream")
+}

--- a/internal/progresslog/logger.go
+++ b/internal/progresslog/logger.go
@@ -34,6 +34,13 @@ type Update struct {
 type Logger struct {
 	options   LoggerOptions
 	successCh chan struct{}
+
+	// Owned by the single goroutine that handles a stream's lines. Stream
+	// attempts are sequential, so no locking is needed.
+	progressBar    *progressbar.ProgressBar
+	barTransferred int64
+	barMax         int64
+	barFinished    bool
 }
 
 type LoggerOptions struct {
@@ -98,6 +105,29 @@ func (l *Logger) MarkAsComplete(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// Rendered reports whether the bar has drawn anything. A bar that never got a
+// progress update never rendered, so nothing needs to terminate its line.
+func (l *Logger) Rendered() bool {
+	return l.barTransferred > 0 || l.barFinished
+}
+
+// FinishBar completes the bar's rendering. The in-stream completion signal can
+// be consumed by the retry loop instead of the render loop, so a caller that
+// joined the goroutines calls this to finish the bar deterministically. Only
+// safe once the follower has stopped, and only meaningful once the bar drew
+// something.
+func (l *Logger) FinishBar(logger *slog.Logger) {
+	if l.progressBar == nil || l.barFinished || l.barTransferred == 0 {
+		return
+	}
+
+	l.barFinished = true
+
+	if err := l.progressBar.Finish(); err != nil {
+		logger.Debug("failed to finish progress bar", "error", err)
+	}
 }
 
 func (l *Logger) startSingle(ctx context.Context, logger *slog.Logger) error {
@@ -207,17 +237,97 @@ func tailLogs(ctx context.Context, stream io.Reader, logCh chan<- string) error 
 	}
 }
 
-//nolint:cyclop,funlen
 func (l *Logger) handleLogs(ctx context.Context, logCh <-chan string, logger *slog.Logger) {
-	var progressBar *progressbar.ProgressBar
+	progressBar := l.progressBarOnce()
 
-	if l.options.ShowProgressBar {
-		progressBar = progressbar.NewOptions64(
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-l.successCh:
+			if progressBar != nil && !l.barFinished {
+				l.barFinished = true
+
+				if err := progressBar.Finish(); err != nil {
+					logger.Debug("failed to finish progress bar", "error", err)
+				}
+			}
+
+			return
+		case logLine := <-logCh:
+			l.handleLine(ctx, progressBar, logLine, logger)
+		}
+	}
+}
+
+func (l *Logger) handleLine(
+	ctx context.Context,
+	progressBar *progressbar.ProgressBar,
+	logLine string,
+	logger *slog.Logger,
+) {
+	if l.options.ParseLineFunc == nil {
+		return
+	}
+
+	progress, err := l.options.ParseLineFunc(logLine)
+	if err != nil {
+		logger.Log(ctx, slog.LevelDebug-1, "failed to parse progress line", "error", err)
+
+		return
+	}
+
+	if !l.options.ShowProgressBar {
+		args := []any{
+			slog.Group(
+				"progress",
+				"transferred",
+				progress.Transferred,
+				"total",
+				progress.Total,
+				"percentage",
+				progress.Percentage,
+			),
+		}
+
+		if l.options.Source != "" {
+			args = append(args, slog.String("source", l.options.Source))
+		}
+
+		logger.Debug(logLine, args...)
+
+		return
+	}
+
+	// Monotonic on purpose: the transferred count never legitimately goes
+	// backward within one transfer, so anything lower is a stray line, and
+	// moving a bar that already completed would strand its finished render.
+	if progress.Transferred < l.barTransferred {
+		return
+	}
+
+	l.barTransferred = progress.Transferred
+
+	if err = l.updateProgressBar(progressBar, progress.Transferred, progress.Total); err != nil {
+		logger.Warn("🔶 Failed to update progress bar", "error", err, "progress", progress)
+	}
+}
+
+// progressBarOnce returns the transfer's one progress bar, creating it on first
+// use. One bar for the Logger's whole lifetime rather than one per stream
+// attempt: an ended stream is retried, and a fresh bar per retry would render
+// its blank state over the finished one and restart the rate estimate.
+func (l *Logger) progressBarOnce() *progressbar.ProgressBar {
+	if !l.options.ShowProgressBar {
+		return nil
+	}
+
+	if l.progressBar == nil {
+		l.progressBar = progressbar.NewOptions64(
 			1,
 			progressbar.OptionSetWriter(l.options.Writer),
 			progressbar.OptionEnableColorCodes(true),
 			progressbar.OptionShowBytes(true),
-			progressbar.OptionSetRenderBlankState(true),
 			progressbar.OptionFullWidth(),
 			progressbar.OptionOnCompletion(func() {
 				fmt.Fprintln(l.options.Writer)
@@ -226,61 +336,20 @@ func (l *Logger) handleLogs(ctx context.Context, logCh <-chan string, logger *sl
 		)
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-l.successCh:
-			if l.options.ShowProgressBar {
-				if err := progressBar.Finish(); err != nil {
-					logger.Debug("failed to finish progress bar", "error", err)
-				}
-			}
-
-			return
-		case logLine := <-logCh:
-			if l.options.ParseLineFunc == nil {
-				continue
-			}
-
-			progress, err := l.options.ParseLineFunc(logLine)
-			if err != nil {
-				logger.Log(ctx, slog.LevelDebug-1, "failed to parse progress line", "error", err)
-
-				continue
-			}
-
-			if !l.options.ShowProgressBar {
-				args := []any{
-					slog.Group(
-						"progress",
-						"transferred",
-						progress.Transferred,
-						"total",
-						progress.Total,
-						"percentage",
-						progress.Percentage,
-					),
-				}
-
-				if l.options.Source != "" {
-					args = append(args, slog.String("source", l.options.Source))
-				}
-
-				logger.Debug(logLine, args...)
-			} else {
-				if err = updateProgressBar(progressBar, progress.Transferred, progress.Total); err != nil {
-					logger.Warn("🔶 Failed to update progress bar", "error", err, "progress", progress)
-				}
-			}
-		}
-	}
+	return l.progressBar
 }
 
-func updateProgressBar(progressBar *progressbar.ProgressBar, transferred, total int64) error {
-	progressBar.ChangeMax64(total)
+func (l *Logger) updateProgressBar(progressBar *progressbar.ProgressBar, transferred, total int64) error {
+	// Raise-only, and only when it actually grew: the library re-renders on
+	// every max change using the previous transferred count, so an unconditional
+	// call painted a strictly lower percentage before each real update and the
+	// bar visibly stepped backward on every other frame.
+	if total > l.barMax {
+		l.barMax = total
+		progressBar.ChangeMax64(total)
+	}
 
-	if total == 0 { // cannot update progress bar when its max is 0
+	if l.barMax == 0 { // cannot update progress bar when its max is 0
 		return nil
 	}
 

--- a/internal/rclone/exitcode.go
+++ b/internal/rclone/exitcode.go
@@ -1,0 +1,25 @@
+package rclone
+
+// exitCodeMeanings are the rclone exit values worth naming, as its documentation
+// words them. The table is deliberately short: rclone puts almost everything
+// under codes 2 and 7, which say no more than "an error", and the job runs with
+// --use-json-log, so the log tail is where the diagnosis actually is. Code 1 is
+// left out on the same evidence: rclone was observed exiting 1 for a credentials
+// failure, so quoting its documented "syntax or usage error" would mislead.
+// Codes with nothing distinct to say, including ones rclone adds later, get the
+// bare number and let the tail speak.
+var exitCodeMeanings = map[int]string{
+	3: "Directory not found",
+	4: "File not found",
+}
+
+// Interpret returns what rclone's documentation says about an exit status, or an
+// empty string when there is nothing distinct to say about it.
+func Interpret(code int) string {
+	meaning, ok := exitCodeMeanings[code]
+	if !ok {
+		return ""
+	}
+
+	return "rclone documents this exit code as: " + meaning
+}

--- a/internal/rclone/exitcode_test.go
+++ b/internal/rclone/exitcode_test.go
@@ -1,0 +1,37 @@
+package rclone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/utkuozdemir/pv-migrate/internal/rclone"
+)
+
+func TestInterpret(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		code int
+		want string
+	}{
+		// Code 1 deliberately gets no meaning: rclone was observed exiting 1 for
+		// a credentials failure, so its documented "syntax or usage error" would
+		// mislead next to the log tail that names the real cause.
+		"usage error":   {code: 1, want: ""},
+		"no directory":  {code: 3, want: `rclone documents this exit code as: Directory not found`},
+		"no file":       {code: 4, want: `rclone documents this exit code as: File not found`},
+		"success":       {code: 0, want: ""},
+		"uncategorised": {code: 2, want: ""},
+		"fatal":         {code: 7, want: ""},
+		"newer code":    {code: 10, want: ""},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, rclone.Interpret(tt.code))
+		})
+	}
+}

--- a/internal/rsync/exitcode.go
+++ b/internal/rsync/exitcode.go
@@ -1,0 +1,58 @@
+package rsync
+
+// exitCodeMeanings are rsync's exit values as its manual page words them. They
+// are quoted rather than paraphrased on purpose: an exit code is an observed
+// fact, its documented meaning is another one, and the scenario that produced it
+// is neither. Code 23 alone covers unreadable sources, unwritable destinations
+// and broken symlinks, so naming any of them would be a guess.
+var exitCodeMeanings = map[int]string{
+	1:  "Syntax or usage error",
+	2:  "Protocol incompatibility",
+	3:  "Errors selecting input/output files, dirs",
+	4:  "Requested action not supported",
+	5:  "Error starting client-server protocol",
+	6:  "Daemon unable to append to log-file",
+	10: "Error in socket I/O",
+	11: "Error in file I/O",
+	12: "Error in rsync protocol data stream",
+	13: "Errors with program diagnostics",
+	14: "Error in IPC code",
+	20: "Received SIGUSR1 or SIGINT",
+	21: "Some error returned by waitpid()",
+	22: "Error allocating core memory buffers",
+	23: "Partial transfer due to error",
+	24: "Partial transfer due to vanished source files",
+	25: "The --max-delete limit stopped deletions",
+	30: "Timeout in data send/receive",
+	35: "Timeout waiting for daemon connection",
+}
+
+// VanishedFilesExitCode is what rsync exits with when files disappeared from the
+// source while it was reading them. Everything it did transfer is intact.
+const VanishedFilesExitCode = 24
+
+// VanishedFilesMarker is the start of the line the chart's rsync job script
+// prints when it treats a vanished-files exit as a success. The client scans
+// the job log for it, and the script render test asserts the script still
+// prints it, which is what keeps the two spellings from drifting apart.
+const VanishedFilesMarker = "pv-migrate: some source files vanished during the transfer"
+
+// remoteShellExitCode is not an rsync exit value. rsync passes the remote
+// shell's status through, and ssh uses this one for its own failures.
+const remoteShellExitCode = 255
+
+// Interpret returns what rsync's documentation says about an exit status, or an
+// empty string when the status is not one it documents.
+func Interpret(code int) string {
+	if code == remoteShellExitCode {
+		return "255 is not an rsync exit value: rsync passes through the status of the remote shell, " +
+			"and ssh uses 255 for its own errors"
+	}
+
+	meaning, ok := exitCodeMeanings[code]
+	if !ok {
+		return ""
+	}
+
+	return "rsync documents this exit code as: " + meaning
+}

--- a/internal/rsync/exitcode_test.go
+++ b/internal/rsync/exitcode_test.go
@@ -1,0 +1,53 @@
+package rsync_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/utkuozdemir/pv-migrate/internal/rsync"
+)
+
+func TestInterpret(t *testing.T) {
+	t.Parallel()
+
+	const documented = `rsync documents this exit code as: %s`
+
+	tests := map[string]struct {
+		code int
+		want string
+	}{
+		"usage error":  {code: 1, want: fmt.Sprintf(documented, "Syntax or usage error")},
+		"partial":      {code: 23, want: fmt.Sprintf(documented, "Partial transfer due to error")},
+		"timeout":      {code: 30, want: fmt.Sprintf(documented, "Timeout in data send/receive")},
+		"success":      {code: 0, want: ""},
+		"undocumented": {code: 99, want: ""},
+		"negative":     {code: -1, want: ""},
+		"oom kill":     {code: 137, want: ""},
+		"vanished": {
+			code: rsync.VanishedFilesExitCode,
+			want: fmt.Sprintf(documented, "Partial transfer due to vanished source files"),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, rsync.Interpret(tt.code))
+		})
+	}
+}
+
+// Test255IsAttributedToTheRemoteShell pins the one row that is not rsync's:
+// rsync passes the remote shell's status through, so claiming 255 as an rsync
+// meaning would be inventing a cause.
+func TestInterpret255IsAttributedToTheRemoteShell(t *testing.T) {
+	t.Parallel()
+
+	got := rsync.Interpret(255)
+
+	assert.Contains(t, got, "not an rsync exit value")
+	assert.Contains(t, got, "remote shell")
+}

--- a/internal/strategy/clusterip.go
+++ b/internal/strategy/clusterip.go
@@ -13,7 +13,7 @@ type ClusterIP struct{}
 func (r *ClusterIP) Run(ctx context.Context, attempt *migration.Attempt, logger *slog.Logger) error {
 	mig := attempt.Migration
 	if reason := r.cannotDoReason(mig); reason != "" {
-		return fmt.Errorf("%s: %w", reason, ErrUnaccepted)
+		return Declined(reason)
 	}
 
 	topo := resolveTopology(mig)
@@ -25,8 +25,17 @@ func (r *ClusterIP) Run(ctx context.Context, attempt *migration.Attempt, logger 
 		return fmt.Errorf("failed to build helm values: %w", err)
 	}
 
-	if err = installHelmChart(attempt, mig.DestInfo, releaseName, helmVals, logger); err != nil {
-		return fmt.Errorf("failed to install helm chart: %w", err)
+	if err = installHelmChart(ctx, attempt, mig.DestInfo, releaseName, helmVals, logger); err != nil {
+		return err
+	}
+
+	// This one release spans two namespaces when source and destination differ:
+	// the rsync job lands in the destination's, sshd in the source's. The install
+	// records the former, so the sshd side has to be added for diagnostics to
+	// see it.
+	if mig.SourceInfo.Claim.Namespace != mig.DestInfo.Claim.Namespace {
+		attempt.DiagnosticTargets = append(attempt.DiagnosticTargets,
+			migration.DiagnosticTarget{Release: releaseName, Info: mig.SourceInfo})
 	}
 
 	return waitForRsyncJob(ctx, attempt, topo.rsync.info, releaseName, logger)

--- a/internal/strategy/linetail.go
+++ b/internal/strategy/linetail.go
@@ -1,0 +1,70 @@
+package strategy
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// sessionTailLines bounds the raw lines kept from a local rsync session, which
+// unlike an in-cluster job has no log to fetch back after a failure.
+const sessionTailLines = 20
+
+// lineTail is a writer that keeps the last raw lines written through it. It
+// splits on both line feeds and the carriage returns rsync uses to redraw its
+// progress line, and it holds an unterminated final line too, since a process
+// that dies mid-line dies on the line worth reading.
+type lineTail struct {
+	mu      sync.Mutex
+	limit   int
+	partial []byte
+	lines   []string
+}
+
+func (t *lineTail) Write(data []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.partial = append(t.partial, data...)
+
+	for {
+		idx := bytes.IndexAny(t.partial, "\r\n")
+		if idx < 0 {
+			break
+		}
+
+		line := strings.TrimSpace(string(t.partial[:idx]))
+		t.partial = t.partial[idx+1:]
+
+		if line != "" {
+			t.record(line)
+		}
+	}
+
+	return len(data), nil
+}
+
+// Lines returns the recorded lines, oldest first, including a trailing
+// unterminated one.
+func (t *lineTail) Lines() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	lines := slices.Clone(t.lines)
+
+	if rest := strings.TrimSpace(string(t.partial)); rest != "" {
+		lines = append(lines, rest)
+	}
+
+	return lines
+}
+
+func (t *lineTail) record(line string) {
+	if len(t.lines) == t.limit {
+		copy(t.lines, t.lines[1:])
+		t.lines = t.lines[:t.limit-1]
+	}
+
+	t.lines = append(t.lines, line)
+}

--- a/internal/strategy/local.go
+++ b/internal/strategy/local.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"time"
 
 	gossh "golang.org/x/crypto/ssh"
@@ -30,8 +31,7 @@ func (r *Local) Run(ctx context.Context, attempt *migration.Attempt, logger *slo
 	req := mig.Request
 
 	if req.Detach {
-		return fmt.Errorf("local strategy requires a persistent connection through the local machine: %w",
-			ErrUnaccepted)
+		return Declined("local strategy requires a persistent connection through the local machine")
 	}
 
 	if hasHelmOverrides(req) {
@@ -49,21 +49,21 @@ func (r *Local) Run(ctx context.Context, attempt *migration.Attempt, logger *slo
 	attempt.ReleaseNames = []string{srcReleaseName, destReleaseName}
 
 	if err = installLocalOnSource(
-		attempt, srcReleaseName, publicKey, privateKey, privateKeyMountPath, logger,
+		ctx, attempt, srcReleaseName, publicKey, privateKey, privateKeyMountPath, logger,
 	); err != nil {
 		return fmt.Errorf("failed to install on source: %w", err)
 	}
 
-	if err = installLocalOnDest(attempt, destReleaseName, publicKey, logger); err != nil {
+	if err = installLocalOnDest(ctx, attempt, destReleaseName, publicKey, logger); err != nil {
 		return fmt.Errorf("failed to install on dest: %w", err)
 	}
 
-	srcPod, err := getSshdPodForHelmRelease(ctx, mig.SourceInfo, srcReleaseName)
+	srcPod, err := getSshdPodForHelmRelease(ctx, mig.SourceInfo, srcReleaseName, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get source sshd pod: %w", err)
 	}
 
-	destPod, err := getSshdPodForHelmRelease(ctx, mig.DestInfo, destReleaseName)
+	destPod, err := getSshdPodForHelmRelease(ctx, mig.DestInfo, destReleaseName, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get dest sshd pod: %w", err)
 	}
@@ -224,18 +224,16 @@ func runRsyncSession(
 ) error {
 	reader, writer := io.Pipe()
 
-	session.Stdout = writer
-	session.Stderr = writer
+	// The tail records at the source, before the pipe: the async progress
+	// pipeline may still be draining when the session ends, but this writer has
+	// already seen every byte, so a failure message never misses the last lines.
+	tail := &lineTail{limit: sessionTailLines}
+	output := io.MultiWriter(tail, writer)
 
-	progressLogger := progresslog.NewLogger(progresslog.LoggerOptions{
-		Writer:          req.Writer,
-		ShowProgressBar: req.ShowProgressBar,
-		LogStreamFunc: func(context.Context) (io.ReadCloser, error) {
-			return reader, nil
-		},
-		ParseLineFunc: rsyncprogress.ParseLine,
-		Source:        rsyncComponent,
-	})
+	session.Stdout = output
+	session.Stderr = output
+
+	progressLogger := sessionProgressLogger(req, reader)
 
 	// rsyncDone is closed by the rsync goroutine after it finishes (and after its deferred
 	// cleanups run), so the context-watcher goroutine knows when to exit.
@@ -268,19 +266,135 @@ func runRsyncSession(
 
 	// Rsync runner: executes rsync on the source pod via SSH, then tears down shared
 	// resources so the other goroutines can exit cleanly.
+	var vanished bool
+
 	eg.Go(func() error {
 		defer close(rsyncDone)
 		defer func() { logClose(writer, logger, "🔶 Failed to close pipe writer") }()
 		defer func() { logClose(tunnelListener, logger, "🔶 Failed to close tunnel listener") }()
 
-		if runErr := session.Run(rsyncCmd); runErr != nil {
-			return fmt.Errorf("rsync session failed: %w", runErr)
-		}
+		var sessionVanished bool
 
-		return progressLogger.MarkAsComplete(ctx)
+		err := completeRsyncSession(ctx, session.Run(rsyncCmd), progressLogger, &sessionVanished)
+		vanished = sessionVanished
+
+		return err
 	})
 
-	return eg.Wait() //nolint:wrapcheck
+	// The group is joined before anything is reported: the progress bar owns the
+	// output until every goroutine has stopped, and the tail is complete by now.
+	return finishRsyncSession(eg.Wait(), vanished, tail, progressLogger, logger)
+}
+
+// finishRsyncSession reports the joined group's outcome. Only the session's own
+// failure gets the exit-status interpretation and the output tail; any other
+// error passes through untouched.
+func finishRsyncSession(
+	waitErr error, vanished bool, tail *lineTail, progressLogger *progresslog.Logger, logger *slog.Logger,
+) error {
+	if waitErr != nil {
+		var sessionErr *rsyncRunError
+		if errors.As(waitErr, &sessionErr) {
+			return rsyncSessionError(sessionErr.err, tail.Lines())
+		}
+
+		return waitErr //nolint:wrapcheck
+	}
+
+	progressLogger.FinishBar(logger)
+
+	if vanished {
+		logger.Warn("🔶 Completed with a warning: some source files vanished during the transfer and were skipped. " +
+			"Re-run the migration, or copy from a source that is not being written to")
+	}
+
+	return nil
+}
+
+// sessionProgressLogger tails the pipe the rsync session writes into.
+func sessionProgressLogger(req *migration.Request, reader io.ReadCloser) *progresslog.Logger {
+	return progresslog.NewLogger(progresslog.LoggerOptions{
+		Writer:          req.Writer,
+		ShowProgressBar: req.ShowProgressBar,
+		LogStreamFunc: func(context.Context) (io.ReadCloser, error) {
+			return reader, nil
+		},
+		ParseLineFunc: rsyncprogress.ParseLine,
+		Source:        rsyncComponent,
+	})
+}
+
+// exitStatusError is a failure that carries the status the remote command exited
+// with. The interface rather than the concrete type, because the SSH exit error's
+// status cannot be set from outside its own package and so cannot be tested for.
+type exitStatusError interface {
+	error
+	ExitStatus() int
+}
+
+var _ exitStatusError = (*gossh.ExitError)(nil)
+
+// rsyncRunError marks a failure of the rsync session itself, as opposed to the
+// tunnel or the progress logger, so the caller knows which error to explain
+// with the session's exit status and output tail.
+type rsyncRunError struct {
+	err error
+}
+
+func (e *rsyncRunError) Error() string { return e.err.Error() }
+
+func (e *rsyncRunError) Unwrap() error { return e.err }
+
+// completeRsyncSession turns the session's result into the attempt's result.
+// A vanished-files exit falls through to the completion signal rather than
+// returning early: the progress logger keeps retrying the closed pipe until it
+// is told the transfer is done, so an early return would never let the group
+// finish. The vanished flag is reported back rather than logged here, because
+// the progress bar still owns the output at this point.
+func completeRsyncSession(
+	ctx context.Context,
+	runErr error,
+	progressLogger *progresslog.Logger,
+	vanished *bool,
+) error {
+	if runErr != nil {
+		if !isVanishedSourceFiles(runErr) {
+			return &rsyncRunError{err: runErr}
+		}
+
+		*vanished = true
+	}
+
+	return progressLogger.MarkAsComplete(ctx)
+}
+
+// isVanishedSourceFiles reports whether rsync stopped only because files
+// disappeared from the source while it was reading them. There is no retry
+// script on this path, so the in-cluster script's rule lands here instead.
+func isVanishedSourceFiles(runErr error) bool {
+	var exitErr exitStatusError
+
+	return errors.As(runErr, &exitErr) && exitErr.ExitStatus() == rsync.VanishedFilesExitCode
+}
+
+// rsyncSessionError explains a failed local rsync session with what was observed:
+// the status the session reported, rsync's documented meaning for it, and the
+// last raw output lines, which unlike an in-cluster job have no log to fetch back.
+func rsyncSessionError(runErr error, recentLines []string) error {
+	err := fmt.Errorf("rsync session failed: %w", runErr)
+
+	var exitErr exitStatusError
+	if errors.As(runErr, &exitErr) {
+		if meaning := rsync.Interpret(exitErr.ExitStatus()); meaning != "" {
+			err = fmt.Errorf("%w (%s)", err, meaning)
+		}
+	}
+
+	if len(recentLines) > 0 {
+		err = fmt.Errorf("%w\nlast lines of rsync output:\n%s", err, strings.Join(recentLines, "\n"))
+	}
+
+	return err
 }
 
 func forwardTunnelConnections(ctx context.Context, listener net.Listener, destPort int, logger *slog.Logger) error {
@@ -373,6 +487,7 @@ func getSshdPodForHelmRelease(
 	ctx context.Context,
 	pvcInfo *pvc.Info,
 	name string,
+	logger *slog.Logger,
 ) (*corev1.Pod, error) {
 	labelSelector := "app.kubernetes.io/component=sshd,app.kubernetes.io/instance=" + name
 
@@ -381,6 +496,7 @@ func getSshdPodForHelmRelease(
 		pvcInfo.ClusterClient.KubeClient,
 		pvcInfo.Claim.Namespace,
 		labelSelector,
+		logger,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sshd pod for helm release %s: %w", name, err)
@@ -390,6 +506,7 @@ func getSshdPodForHelmRelease(
 }
 
 func installLocalOnSource(
+	ctx context.Context,
 	attempt *migration.Attempt,
 	releaseName, publicKey, privateKey, privateKeyMountPath string,
 	logger *slog.Logger,
@@ -406,15 +523,18 @@ func installLocalOnSource(
 	sshdVals["privateKey"] = privateKey
 	sshdVals["privateKeyMountPath"] = privateKeyMountPath
 
-	return installHelmChart(attempt, mig.SourceInfo, releaseName, map[string]any{sshdComponent: sshdVals}, logger)
+	return installHelmChart(ctx, attempt, mig.SourceInfo, releaseName, map[string]any{sshdComponent: sshdVals}, logger)
 }
 
-func installLocalOnDest(attempt *migration.Attempt, releaseName, publicKey string, logger *slog.Logger) error {
+func installLocalOnDest(
+	ctx context.Context, attempt *migration.Attempt, releaseName, publicKey string, logger *slog.Logger,
+) error {
 	mig := attempt.Migration
 	side := componentSide{info: mig.DestInfo, mountPath: destMountPath}
 
 	return installHelmChart(
-		attempt, mig.DestInfo, releaseName, map[string]any{sshdComponent: buildSshdHelmValues(side, publicKey)}, logger,
+		ctx, attempt, mig.DestInfo, releaseName,
+		map[string]any{sshdComponent: buildSshdHelmValues(side, publicKey)}, logger,
 	)
 }
 

--- a/internal/strategy/local_test.go
+++ b/internal/strategy/local_test.go
@@ -1,0 +1,127 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/neilotoole/slogt/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/pv-migrate/internal/progresslog"
+	rsyncprogress "github.com/utkuozdemir/pv-migrate/internal/rsync/progress"
+)
+
+// stubExitError stands in for the SSH exit error, whose status cannot be set from
+// outside its own package.
+type stubExitError struct {
+	status int
+}
+
+func (e *stubExitError) Error() string {
+	return fmt.Sprintf("Process exited with status %d", e.status)
+}
+
+func (e *stubExitError) ExitStatus() int {
+	return e.status
+}
+
+// TestCompleteRsyncSessionOnVanishedFiles guards against a hang rather than a
+// wrong value. The progress logger retries its stream until it is told the
+// transfer finished, so treating exit 24 as a success by returning early would
+// leave it running and the group it belongs to would never finish.
+func TestCompleteRsyncSessionOnVanishedFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := slogt.New(t)
+
+	reader, writer := io.Pipe()
+
+	progressLogger := progresslog.NewLogger(progresslog.LoggerOptions{
+		Writer:        io.Discard,
+		LogStreamFunc: func(context.Context) (io.ReadCloser, error) { return reader, nil },
+		ParseLineFunc: rsyncprogress.ParseLine,
+	})
+
+	done := make(chan error, 1)
+
+	go func() { done <- progressLogger.Start(ctx, logger) }()
+
+	// The session ended, so its output stream ends with it.
+	require.NoError(t, writer.Close())
+
+	var vanished bool
+
+	require.NoError(t, completeRsyncSession(ctx, &stubExitError{status: 24}, progressLogger, &vanished))
+	assert.True(t, vanished)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the progress logger never finished, so a vanished-files exit would deadlock the migration")
+	}
+}
+
+// TestCompleteRsyncSessionOnFailure pins that a real failure comes back marked
+// as the session's own, so the caller explains it with the exit status and the
+// output tail once the progress goroutines have stopped.
+func TestCompleteRsyncSessionOnFailure(t *testing.T) {
+	t.Parallel()
+
+	progressLogger := progresslog.NewLogger(progresslog.LoggerOptions{Writer: io.Discard})
+
+	var vanished bool
+
+	err := completeRsyncSession(t.Context(), &stubExitError{status: 23}, progressLogger, &vanished)
+	require.Error(t, err)
+	assert.False(t, vanished)
+
+	var sessionErr *rsyncRunError
+
+	require.ErrorAs(t, err, &sessionErr)
+	assert.Contains(t, sessionErr.Error(), "Process exited with status 23")
+
+	enriched := rsyncSessionError(sessionErr.err, []string{"some raw line"})
+	assert.Contains(t, enriched.Error(), `rsync documents this exit code as: Partial transfer due to error`)
+}
+
+// TestLineTailCapturesAtTheSource pins the property the tail exists for: it has
+// seen everything the moment a write returns, including a final line without a
+// newline, so a failure message built right after the session ends is complete.
+func TestLineTailCapturesAtTheSource(t *testing.T) {
+	t.Parallel()
+
+	tail := &lineTail{limit: 3}
+
+	_, err := tail.Write([]byte("one\ntwo\rthree\nfour\nrsync error: some fatal thing (code 12)"))
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"two", "three", "four", "rsync error: some fatal thing (code 12)"},
+		tail.Lines())
+}
+
+func TestRsyncSessionErrorKeepsTheRawOutput(t *testing.T) {
+	t.Parallel()
+
+	err := rsyncSessionError(&stubExitError{status: 12}, []string{"rsync: connection unexpectedly closed", "tail"})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), `rsync documents this exit code as: Error in rsync protocol data stream`)
+	assert.Contains(t, err.Error(), "last lines of rsync output:\nrsync: connection unexpectedly closed\ntail")
+}
+
+// TestRsyncSessionErrorWithoutAnExitStatus covers the failures that never ran
+// rsync at all, where there is no code to interpret.
+func TestRsyncSessionErrorWithoutAnExitStatus(t *testing.T) {
+	t.Parallel()
+
+	err := rsyncSessionError(io.ErrUnexpectedEOF, nil)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.NotContains(t, err.Error(), "rsync documents")
+}

--- a/internal/strategy/mount.go
+++ b/internal/strategy/mount.go
@@ -14,7 +14,7 @@ type Mount struct{}
 func (r *Mount) Run(ctx context.Context, attempt *migration.Attempt, logger *slog.Logger) error {
 	mig := attempt.Migration
 	if reason := r.cannotDoReason(mig); reason != "" {
-		return fmt.Errorf("%s: %w", reason, ErrUnaccepted)
+		return Declined(reason)
 	}
 
 	sourceInfo := attempt.Migration.SourceInfo
@@ -52,9 +52,8 @@ func (r *Mount) Run(ctx context.Context, attempt *migration.Attempt, logger *slo
 	releaseName := attempt.HelmReleaseNamePrefix
 	attempt.ReleaseNames = []string{releaseName}
 
-	err = installHelmChart(attempt, sourceInfo, releaseName, vals, logger)
-	if err != nil {
-		return fmt.Errorf("failed to install helm chart: %w", err)
+	if err = installHelmChart(ctx, attempt, sourceInfo, releaseName, vals, logger); err != nil {
+		return err
 	}
 
 	return waitForRsyncJob(ctx, attempt, sourceInfo, releaseName, logger)

--- a/internal/strategy/nodeport.go
+++ b/internal/strategy/nodeport.go
@@ -33,7 +33,7 @@ func resolveNodePortTarget(
 		return sshTarget{}, fmt.Errorf("failed to get NodePort: %w", err)
 	}
 
-	sshdPod, err := getSshdPodForHelmRelease(ctx, topo.sshd.info, sshdRelease)
+	sshdPod, err := getSshdPodForHelmRelease(ctx, topo.sshd.info, sshdRelease, logger)
 	if err != nil {
 		return sshTarget{}, fmt.Errorf("failed to get sshd pod: %w", err)
 	}

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -1,6 +1,7 @@
 package strategy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -18,6 +19,8 @@ import (
 	"helm.sh/helm/v4/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+	"github.com/utkuozdemir/pv-migrate/internal/k8s"
 	"github.com/utkuozdemir/pv-migrate/internal/migration"
 	"github.com/utkuozdemir/pv-migrate/internal/pvc"
 )
@@ -64,6 +67,26 @@ var (
 
 	ErrUnaccepted = errors.New("unaccepted")
 )
+
+// DeclinedError reports that a strategy cannot handle this migration, together
+// with the reason it gave. It unwraps to ErrUnaccepted so the ladder's existing
+// check is unaffected, and the reason stays reachable without parsing a message.
+type DeclinedError struct {
+	Reason string
+}
+
+func (e *DeclinedError) Error() string {
+	return e.Reason + ": " + ErrUnaccepted.Error()
+}
+
+func (e *DeclinedError) Unwrap() error {
+	return ErrUnaccepted
+}
+
+// Declined returns the error a strategy returns when it cannot do the job.
+func Declined(reason string) error {
+	return &DeclinedError{Reason: reason}
+}
 
 type Strategy interface {
 	// Run runs the migration for the given task execution.
@@ -227,12 +250,20 @@ func getMergedHelmValues(
 }
 
 func installHelmChart(
+	ctx context.Context,
 	attempt *migration.Attempt,
 	pvcInfo *pvc.Info,
 	name string,
 	values map[string]any,
 	logger *slog.Logger,
 ) error {
+	// Recorded before anything is installed, and here rather than reconstructed
+	// later, because this is the one point every strategy passes through and the
+	// only one that knows which cluster and namespace this release goes into. An
+	// install that creates nothing simply yields nothing to report.
+	attempt.DiagnosticTargets = append(attempt.DiagnosticTargets,
+		migration.DiagnosticTarget{Release: name, Info: pvcInfo})
+
 	helmActionConfig, err := initHelmActionConfig(pvcInfo)
 	if err != nil {
 		return fmt.Errorf("failed to init helm action config: %w", err)
@@ -245,11 +276,8 @@ func installHelmChart(
 	install.ReleaseName = name
 	install.WaitStrategy = kube.LegacyStrategy
 
-	if req := mig.Request; req.HelmTimeout < req.LoadBalancerTimeout {
-		install.Timeout = req.LoadBalancerTimeout
-	} else {
-		install.Timeout = req.HelmTimeout
-	}
+	timeout, timeoutFlag := effectiveInstallTimeout(mig.Request, values)
+	install.Timeout = timeout
 
 	applyNonRootValues(values, mig.Request)
 
@@ -258,9 +286,102 @@ func installHelmChart(
 		return fmt.Errorf("failed to get merged helm values: %w", err)
 	}
 
+	// A long wait usually means the cluster already knows what is stuck, so at
+	// half the budget the resources are peeked at once, turning the silent half
+	// of the wait into an answer.
+	stopPeek := peekAfter(timeout/2, func() {
+		writeMidInstallDiagnostics(ctx, attempt, pvcInfo, name, logger)
+	})
+	defer stopPeek()
+
 	if _, err = install.Run(mig.Chart, vals); err != nil {
+		// The bare context error names no duration and no knob, and it is the
+		// headline of every stuck-resource failure.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf(
+				"timed out after %s waiting for the release's resources to become ready (see %s): %w",
+				timeout, timeoutFlag, err)
+		}
+
 		return fmt.Errorf("failed to install helm chart: %w", err)
 	}
 
 	return nil
+}
+
+// effectiveInstallTimeout picks the install wait budget and names the flag it
+// came from. The load balancer timeout only applies when this release actually
+// waits for a load balancer, so a LoadBalancer-only flag cannot silently
+// lengthen every other strategy's install.
+func effectiveInstallTimeout(req *migration.Request, values map[string]any) (time.Duration, string) {
+	if installsLoadBalancer(values) && req.LoadBalancerTimeout > req.HelmTimeout {
+		return req.LoadBalancerTimeout, "--loadbalancer-timeout, which exceeds --helm-timeout"
+	}
+
+	return req.HelmTimeout, "--helm-timeout"
+}
+
+// installsLoadBalancer reports whether the values ask for a LoadBalancer
+// service, which the install wait then waits on.
+func installsLoadBalancer(values map[string]any) bool {
+	sshd, ok := values[sshdComponent].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	service, ok := sshd["service"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	return service["type"] == "LoadBalancer"
+}
+
+// peekAfter runs the peek once after the delay unless stopped first.
+func peekAfter(delay time.Duration, peek func()) func() {
+	done := make(chan struct{})
+
+	go func() {
+		select {
+		case <-done:
+		case <-time.After(delay):
+			peek()
+		}
+	}()
+
+	return func() { close(done) }
+}
+
+// writeMidInstallDiagnostics narrates a still-running install wait with what the
+// cluster reports at that moment, on the same writer and in the same shape the
+// failure block would use. Log records carry it on a structured stream.
+func writeMidInstallDiagnostics(
+	ctx context.Context,
+	attempt *migration.Attempt,
+	pvcInfo *pvc.Info,
+	release string,
+	logger *slog.Logger,
+) {
+	req := attempt.Migration.Request
+	cli := pvcInfo.ClusterClient.KubeClient
+	ns := pvcInfo.Claim.Namespace
+
+	if req.StructuredLogs {
+		var buf bytes.Buffer
+
+		k8s.WriteWorkloadDiagnostics(ctx, cli, ns,
+			k8s.InstanceLabelSelector(release), console.Palette{}, &buf, logger)
+		logger.Warn("🔶 Still waiting for the release's resources; what the cluster reports so far",
+			"release", release, "namespace", ns, "diagnostics", buf.String())
+
+		return
+	}
+
+	palette := console.Palette{Enabled: req.ColorOutput}
+
+	fmt.Fprintf(req.Writer, "\n%s\n\n  %s (namespace %s):\n",
+		palette.Bold("Still waiting; what the cluster reports so far:"), release, ns)
+	k8s.WriteWorkloadDiagnostics(ctx, cli, ns,
+		k8s.InstanceLabelSelector(release), palette, req.Writer, logger)
+	fmt.Fprintln(req.Writer)
 }

--- a/internal/strategy/topology.go
+++ b/internal/strategy/topology.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/k8s"
 	"github.com/utkuozdemir/pv-migrate/internal/migration"
 	"github.com/utkuozdemir/pv-migrate/internal/pvc"
@@ -99,7 +100,7 @@ func runTwoReleaseStrategy(
 	sshdRelease, rsyncRelease := releases[0], releases[1]
 	attempt.ReleaseNames = releases[:]
 
-	if err = installSshd(attempt, topo, sshdRelease, publicKey, serviceType, logger); err != nil {
+	if err = installSshd(ctx, attempt, topo, sshdRelease, publicKey, serviceType, logger); err != nil {
 		return fmt.Errorf("failed to install sshd: %w", err)
 	}
 
@@ -113,7 +114,7 @@ func runTwoReleaseStrategy(
 		sshTargetHost = formatSSHTargetHost(mig.Request.DestHostOverride)
 	}
 
-	if err = installRsyncJob(attempt, topo, rsyncRelease, privateKey, privateKeyMountPath,
+	if err = installRsyncJob(ctx, attempt, topo, rsyncRelease, privateKey, privateKeyMountPath,
 		sshTargetHost, target.port, logger); err != nil {
 		return fmt.Errorf("failed to install rsync job: %w", err)
 	}
@@ -194,6 +195,7 @@ func buildRsyncHelmValues(side componentSide, rsyncCmd, privateKey, privateKeyMo
 }
 
 func installSshd(
+	ctx context.Context,
 	attempt *migration.Attempt,
 	topo topology,
 	releaseName, publicKey, serviceType string,
@@ -202,10 +204,11 @@ func installSshd(
 	sshdVals := buildSshdHelmValues(topo.sshd, publicKey)
 	sshdVals["service"] = map[string]any{"type": serviceType}
 
-	return installHelmChart(attempt, topo.sshd.info, releaseName, map[string]any{sshdComponent: sshdVals}, logger)
+	return installHelmChart(ctx, attempt, topo.sshd.info, releaseName, map[string]any{sshdComponent: sshdVals}, logger)
 }
 
 func installRsyncJob(
+	ctx context.Context,
 	attempt *migration.Attempt,
 	topo topology,
 	releaseName, privateKey, privateKeyMountPath, sshHost string,
@@ -226,7 +229,8 @@ func installRsyncJob(
 		rsyncVals["sshRemotePort"] = sshPort
 	}
 
-	return installHelmChart(attempt, topo.rsync.info, releaseName, map[string]any{rsyncComponent: rsyncVals}, logger)
+	return installHelmChart(
+		ctx, attempt, topo.rsync.info, releaseName, map[string]any{rsyncComponent: rsyncVals}, logger)
 }
 
 func waitForRsyncJob(
@@ -251,12 +255,14 @@ func waitForRsyncJob(
 		return nil
 	}
 
-	if err := k8s.WaitForJobCompletion(
+	// Deliberately not wrapped: the error already names the failed pod and the
+	// exit state, and the summary row already names the strategy, so a
+	// "failed to wait for job completion" prefix would only push the answer
+	// further right.
+	//nolint:wrapcheck
+	return k8s.WaitForJobCompletion(
 		ctx, kubeClient, namespace, jobName,
-		mig.Request.ShowProgressBar, mig.Request.Writer, logger,
-	); err != nil {
-		return fmt.Errorf("failed to wait for job completion: %w", err)
-	}
-
-	return nil
+		mig.Request.ShowProgressBar, mig.Request.StructuredLogs,
+		console.Palette{Enabled: mig.Request.ColorOutput}, mig.Request.Writer, logger,
+	)
 }

--- a/pvmigrate/backup.go
+++ b/pvmigrate/backup.go
@@ -79,6 +79,15 @@ type Backup struct {
 
 	Writer io.Writer
 	Logger *slog.Logger
+
+	// StructuredLogs reports that Logger writes machine-readable records to the
+	// same stream as Writer. Set it to keep plain-text blocks such as failure
+	// diagnostics out of that stream; the same information is logged instead.
+	StructuredLogs bool
+
+	// ColorOutput colors the plain-text report blocks semantically. Set it only
+	// when Writer is a terminal.
+	ColorOutput bool
 }
 
 // RunBackup executes the backup.
@@ -156,6 +165,8 @@ func toBackupRequest(backup *Backup, direction string) *bucketstorage.Request {
 		HelmFileValues:        backup.HelmFileValues,
 		HelmStringValues:      backup.HelmStringValues,
 		Writer:                backup.Writer,
+		StructuredLogs:        backup.StructuredLogs,
+		ColorOutput:           backup.ColorOutput,
 		Logger:                backup.Logger,
 	}
 }

--- a/pvmigrate/pvmigrate.go
+++ b/pvmigrate/pvmigrate.go
@@ -117,9 +117,22 @@ type Migration struct {
 
 	Writer io.Writer
 	Logger *slog.Logger
+
+	// StructuredLogs reports that Logger writes machine-readable records to the
+	// same stream as Writer. Set it to keep plain-text blocks such as the failure
+	// summary out of that stream; the same information is logged instead.
+	StructuredLogs bool
+
+	// ColorOutput colors the plain-text report blocks semantically. Set it only
+	// when Writer is a terminal.
+	ColorOutput bool
 }
 
 // Run executes the migration.
+//
+// When every requested strategy declines or fails, the returned error's message
+// stays a single line, and the per-strategy errors are reachable through the
+// standard unwrap tree, so errors.Is and errors.As can inspect them.
 func Run(ctx context.Context, migration Migration) error {
 	migration.ApplyDefaults()
 
@@ -229,5 +242,7 @@ func toInternalRequest(mig *Migration) *migration.Request {
 		HelmFileValues:        mig.HelmFileValues,
 		HelmStringValues:      mig.HelmStringValues,
 		Writer:                mig.Writer,
+		StructuredLogs:        mig.StructuredLogs,
+		ColorOutput:           mig.ColorOutput,
 	}
 }

--- a/pvmigrate/restore.go
+++ b/pvmigrate/restore.go
@@ -80,6 +80,15 @@ type Restore struct {
 
 	Writer io.Writer
 	Logger *slog.Logger
+
+	// StructuredLogs reports that Logger writes machine-readable records to the
+	// same stream as Writer. Set it to keep plain-text blocks such as failure
+	// diagnostics out of that stream; the same information is logged instead.
+	StructuredLogs bool
+
+	// ColorOutput colors the plain-text report blocks semantically. Set it only
+	// when Writer is a terminal.
+	ColorOutput bool
 }
 
 // RunRestore executes the restore.
@@ -158,6 +167,8 @@ func toRestoreRequest(restore *Restore) *bucketstorage.Request {
 		HelmFileValues:        restore.HelmFileValues,
 		HelmStringValues:      restore.HelmStringValues,
 		Writer:                restore.Writer,
+		StructuredLogs:        restore.StructuredLogs,
+		ColorOutput:           restore.ColorOutput,
 		Logger:                restore.Logger,
 	}
 }


### PR DESCRIPTION
When every strategy in the ladder failed, the only thing the tool said was that they all failed, which left the user digging through pods that had already been cleaned up. It now reports what it observed: a per-strategy summary that separates a strategy declining the job from one that tried and failed, the exit code the data mover returned together with the meaning that mover's own documentation gives it, the last log lines of the pod that failed, and what the cluster said about the resources involved, including recent warning events. Nothing is inferred. A cause is reported only when it was actually observed, so the output never guesses at one.

The same reporting now covers the other commands. Backup and restore failures print the same block, and the status command shows the failure evidence without needing to follow the operation, reports how long it ran, and exits non-zero when it failed.

Long waits are no longer silent. A pod that cannot start narrates its container's waiting reason as soon as the cluster knows it, and an install still waiting halfway through its budget prints what the cluster reports at that moment. A wait that does time out now says how long it waited and which flag set that budget, and the load balancer budget applies only to the strategy that actually waits for one.

Colored output marks the report semantically when writing to a terminal: the failure headline and hard failures in red, warnings and declines in yellow, healthy facts in green, framing dimmed. The coloring is driven by what the code knows about each line rather than by matching words in the text, and NO_COLOR turns it off. Structured log output stays free of escape sequences and carries the same information as attributes.

Two progress bar defects are fixed along the way: the bar could step backwards on every other frame, and a successful transfer could leave it stranded below completion.

Closes https://github.com/utkuozdemir/pv-migrate/issues/448.


