### PR TITLE
fix: keep log records off the progress bar

### DIFF
--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/util"
 	"github.com/utkuozdemir/pv-migrate/pvmigrate"
 )
@@ -423,7 +424,14 @@ func buildLogger(logLevel, logFormat string, writer io.Writer, isATTY bool) (*sl
 	case logFormatJSON:
 		handler = slog.NewJSONHandler(writer, &slog.HandlerOptions{Level: level})
 	case logFormatText:
-		handler = tint.NewTextHandler(writer, &tint.Options{
+		out := writer
+		if isATTY {
+			// A transfer paints a progress bar on this same terminal, and a
+			// record printed on top of it corrupts both.
+			out = console.EraseLineBefore(writer)
+		}
+
+		handler = tint.NewTextHandler(out, &tint.Options{
 			Level:   level,
 			NoColor: !isATTY || os.Getenv("NO_COLOR") != "",
 		})

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -131,7 +131,8 @@ func followJobProgress(
 
 	palette := console.Palette{Enabled: console.ForTerminal(isatty.IsTerminal(os.Stderr.Fd()), structuredLogs)}
 
-	if err := k8s.WaitForJobCompletion(ctx, cli, job.Namespace, job.Name, true, structuredLogs,
+	if err := k8s.WaitForJobCompletion(ctx, cli, job.Namespace, job.Name,
+		isatty.IsTerminal(os.Stderr.Fd()), structuredLogs,
 		palette, os.Stderr, logger); err != nil {
 		return fmt.Errorf("failed to follow progress: %w", err)
 	}

--- a/internal/console/erase.go
+++ b/internal/console/erase.go
@@ -1,0 +1,48 @@
+package console
+
+import "io"
+
+// eraseLine returns the cursor to the start of the line and clears it.
+const eraseLine = "\r\x1b[2K"
+
+// EraseLineBefore returns a writer that clears the current terminal line ahead
+// of everything written through it, in the same write.
+//
+// A progress bar paints one line and repaints it in place, while log records go
+// to the same terminal with no knowledge of each other. Without this, a record
+// lands on top of the bar's line or strands a copy of it. With it, the record
+// wipes the line the bar painted and prints on a clean one, and the bar paints
+// itself again on its next update.
+//
+// The erase and the record are one write because writes to one terminal are
+// serialised inside the process, which is what stops a record and a bar frame
+// from landing inside each other.
+func EraseLineBefore(w io.Writer) io.Writer {
+	return eraseLineWriter{w: w}
+}
+
+type eraseLineWriter struct {
+	w io.Writer
+}
+
+func (e eraseLineWriter) Write(record []byte) (int, error) {
+	buf := make([]byte, 0, len(eraseLine)+len(record))
+	buf = append(buf, eraseLine...)
+	buf = append(buf, record...)
+
+	written, err := e.w.Write(buf)
+
+	// The caller is owed a count of its own bytes, so the prefix comes back off,
+	// and the result stays inside the range io.Writer promises.
+	written -= len(eraseLine)
+	written = max(written, 0)
+	written = min(written, len(record))
+
+	// A writer that stops early without saying why still owes its caller an
+	// error, which io.Writer requires alongside a short count.
+	if err == nil && written < len(record) {
+		return written, io.ErrShortWrite
+	}
+
+	return written, err //nolint:wrapcheck // a writer passes its own error through
+}

--- a/internal/console/erase_test.go
+++ b/internal/console/erase_test.go
@@ -1,0 +1,232 @@
+package console_test
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/lmittmann/tint"
+	"github.com/schollz/progressbar/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/pv-migrate/internal/console"
+)
+
+// TestRecordDoesNotLandOnTheProgressBar is issue 449 as a test. It paints a real
+// bar, logs a real record the way the CLI does, and paints again. The transcript
+// then goes through a screen, which answers the only question that matters: what
+// a person would have seen.
+func TestRecordDoesNotLandOnTheProgressBar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		eraseFirst bool
+		wantClean  bool
+	}{
+		{name: "records erase the bar's line", eraseFirst: true, wantClean: true},
+		{name: "without erasing, they collide", eraseFirst: false, wantClean: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var transcript bytes.Buffer
+
+			bar := progressbar.NewOptions64(100,
+				progressbar.OptionSetWriter(&transcript),
+				progressbar.OptionUseANSICodes(true),
+				progressbar.OptionFullWidth(),
+				progressbar.OptionSetDescription("Copying data..."))
+
+			var records io.Writer = &transcript
+			if tt.eraseFirst {
+				records = console.EraseLineBefore(&transcript)
+			}
+
+			logger := slog.New(tint.NewTextHandler(records, &tint.Options{NoColor: true}))
+
+			require.NoError(t, bar.Set64(8))
+			logger.Warn("Pod is not starting yet")
+			require.NoError(t, bar.Set64(9))
+
+			rendered := render(transcript.String())
+			screen := strings.Join(rendered, "\n")
+
+			recordLine, found := lineContaining(rendered, "Pod is not starting yet")
+			require.True(t, found, "the record must survive at all:\n%s", screen)
+
+			assert.Equal(t, tt.wantClean, !strings.Contains(recordLine, "Copying data"),
+				"record line was %q in:\n%s", recordLine, screen)
+
+			if !tt.wantClean {
+				return
+			}
+
+			assert.Equal(t, 1, countLinesContaining(rendered, "Copying data"),
+				"one bar, not a stranded copy:\n%s", screen)
+			assert.NotContains(t, recordLine, "|", "no tail of the bar is left beside the record")
+		})
+	}
+}
+
+// TestEachRecordIsOneWrite pins what the fix rests on: a record and its erase
+// reach the terminal together, so a bar frame cannot land between them.
+func TestEachRecordIsOneWrite(t *testing.T) {
+	t.Parallel()
+
+	counter := &countingWriter{}
+	logger := slog.New(tint.NewTextHandler(console.EraseLineBefore(counter), &tint.Options{NoColor: true}))
+
+	logger.Info("one")
+	logger.Info("two", "with", strings.Repeat("a long attribute value ", 200))
+
+	assert.Equal(t, 2, counter.writes, "one write per record, whatever its length")
+
+	for _, written := range counter.parts {
+		assert.True(t, strings.HasPrefix(written, "\r\x1b[2K"), "each write erases first: %q", written)
+	}
+}
+
+func TestEraseLineBeforeCountsOnlyItsCallersBytes(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	payload := []byte("a record\n")
+
+	written, err := console.EraseLineBefore(&buf).Write(payload)
+	require.NoError(t, err)
+	assert.Equal(t, len(payload), written, "a writer reports the bytes it was given")
+	assert.True(t, strings.HasSuffix(buf.String(), string(payload)))
+	assert.Greater(t, buf.Len(), len(payload), "the erase sequence went out with it")
+}
+
+func TestEraseLineBeforeReportsAShortWrite(t *testing.T) {
+	t.Parallel()
+
+	written, err := console.EraseLineBefore(shortWriter{}).Write([]byte("a record\n"))
+	require.ErrorIs(t, err, io.ErrShortWrite)
+	assert.Zero(t, written)
+}
+
+type countingWriter struct {
+	writes int
+	parts  []string
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.writes++
+	c.parts = append(c.parts, string(p))
+
+	return len(p), nil
+}
+
+// shortWriter accepts the erase sequence and nothing else, without saying so.
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	return min(len(p), len("\r\x1b[2K")), nil
+}
+
+// render turns a transcript into the lines a terminal would be showing. It
+// implements only what these tests write: a carriage return returns to the start
+// of the line, a newline starts a new one, CSI K erases to the end of the line,
+// and any other escape sequence is styling that occupies no columns.
+func render(transcript string) []string {
+	lines := [][]rune{{}}
+	row, column := 0, 0
+
+	runes := []rune(transcript)
+
+	for at := 0; at < len(runes); at++ {
+		switch {
+		case runes[at] == '\r':
+			column = 0
+		case runes[at] == '\n':
+			lines = append(lines, []rune{})
+			row++
+			column = 0
+		case isEscape(runes, at):
+			at = applyEscape(runes, at, lines[row], column)
+		default:
+			lines[row] = place(lines[row], column, runes[at])
+			column++
+		}
+	}
+
+	rendered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		rendered = append(rendered, strings.TrimRight(string(line), " "))
+	}
+
+	return rendered
+}
+
+func isEscape(runes []rune, at int) bool {
+	return runes[at] == 0x1b && at+1 < len(runes) && runes[at+1] == '['
+}
+
+// applyEscape handles the one sequence these tests care about, erasing the line,
+// and returns where the sequence ended.
+func applyEscape(runes []rune, at int, line []rune, column int) int {
+	end := at + 2
+	for end < len(runes) && !isFinalByte(runes[end]) {
+		end++
+	}
+
+	if end < len(runes) && runes[end] == 'K' {
+		eraseToEnd(line, string(runes[at+2:end]), column)
+	}
+
+	return end
+}
+
+func isFinalByte(r rune) bool { return r >= '@' && r <= '~' }
+
+func eraseToEnd(line []rune, params string, column int) {
+	from := column
+	if params == "2" { // the whole line, wherever the cursor is
+		from = 0
+	}
+
+	for i := from; i < len(line); i++ {
+		line[i] = ' '
+	}
+}
+
+func place(line []rune, column int, r rune) []rune {
+	for len(line) <= column {
+		line = append(line, ' ')
+	}
+
+	line[column] = r
+
+	return line
+}
+
+func lineContaining(lines []string, text string) (string, bool) {
+	for _, line := range lines {
+		if strings.Contains(line, text) {
+			return line, true
+		}
+	}
+
+	return "", false
+}
+
+func countLinesContaining(lines []string, text string) int {
+	found := 0
+
+	for _, line := range lines {
+		if strings.Contains(line, text) {
+			found++
+		}
+	}
+
+	return found
+}

--- a/internal/k8s/job.go
+++ b/internal/k8s/job.go
@@ -129,6 +129,14 @@ func WaitForJobStart(ctx context.Context, cli kubernetes.Interface,
 // structuredLogs set, everything that would be raw text on the writer travels
 // as log records instead, so a machine-readable stream stays machine-readable.
 //
+// showBar reports whether a progress bar belongs on this run. Never on a
+// structured stream: a bar paints with carriage returns and escape sequences,
+// which have no business in output something else is meant to parse. Decided
+// here, the one place every caller passes through, rather than by each of them.
+func showBar(requested, structuredLogs bool) bool {
+	return requested && !structuredLogs
+}
+
 //nolint:funlen
 func WaitForJobCompletion(ctx context.Context, cli kubernetes.Interface,
 	ns, name string, showProgressBar, structuredLogs bool, palette console.Palette,
@@ -137,6 +145,8 @@ func WaitForJobCompletion(ctx context.Context, cli kubernetes.Interface,
 	if writer == nil {
 		writer = io.Discard
 	}
+
+	showProgressBar = showBar(showProgressBar, structuredLogs)
 
 	pod, handled, err := resolveRunningJobPod(ctx, cli, ns, name, structuredLogs, palette, writer, logger)
 	if handled {

--- a/internal/progresslog/logger.go
+++ b/internal/progresslog/logger.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"runtime"
 	"strings"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/schollz/progressbar/v3"
 	"golang.org/x/sync/errgroup"
 )
@@ -338,6 +341,11 @@ func (l *Logger) progressBarOnce() *progressbar.ProgressBar {
 			barMaximum,
 			progressbar.OptionSetWriter(l.options.Writer),
 			progressbar.OptionEnableColorCodes(true),
+			// An ordinary frame becomes one write, so that a log record cannot
+			// arrive between a clear and a paint and be painted over. The frame
+			// that completes the bar is still followed by a separate newline
+			// below, which is the one gap left.
+			progressbar.OptionUseANSICodes(paintsInOneWrite(l.options.Writer)),
 			progressbar.OptionFullWidth(),
 			progressbar.OptionOnCompletion(func() {
 				fmt.Fprintln(l.options.Writer)
@@ -355,6 +363,24 @@ func (l *Logger) progressBarOnce() *progressbar.ProgressBar {
 // reconstructing one from its rounded percentage produced an estimate that was
 // wrong by up to a factor of two on the first sample and had to be revised for
 // the rest of the transfer.
+// paintsInOneWrite reports whether the bar may paint a frame as a single write
+// that erases the rest of the line.
+//
+// That needs a terminal which reads the erase sequence, and Windows is left out
+// of it: a console there may not interpret one, and the bar would leave the
+// tail of its previous frame on screen instead of clearing it. The two-write
+// clear it falls back to is what shipped before, so nothing is worse there than
+// it was.
+func paintsInOneWrite(writer io.Writer) bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+
+	file, ok := writer.(*os.File)
+
+	return ok && isatty.IsTerminal(file.Fd())
+}
+
 func (l *Logger) updateProgressBar(progressBar *progressbar.ProgressBar, percentage int) error {
 	if err := progressBar.Set64(int64(min(percentage, barStreamedMaximum))); err != nil {
 		return fmt.Errorf("failed to set progress bar value: %w", err)


### PR DESCRIPTION
Closes #449.

A record printed while a transfer's progress bar was on screen landed on top of it or stranded a copy of it. The bar repaints one line in place, the log handler writes to the same terminal, and neither knows about the other. In the CLI both go through the same stderr, and client-go's records come out there too, since `klog` is routed into the same logger.

Two measurements decided the fix, taken against the libraries rather than reasoned about: one bar update was **two** writes, a clear and then the frame, which is the gap a record was landing in, and one log record is **one** write.

So records now erase the line ahead of themselves in the same write, and an ordinary bar frame became one write. Writes to one terminal are serialised inside the process, so neither can land inside the other: a record wipes whatever the bar painted, prints on a clean line, and the bar paints itself again on its next update. There is nothing left to coordinate, so there is no coordinator, no lock and no lifecycle.

Both halves apply only where they mean something. Records erase only when the logs are text on a terminal. The single-write frame is used only on a terminal that is not a Windows console, since one there may not read the erase sequence and would be left showing the tail of its previous frame; that platform keeps the behaviour it already had.

A progress bar is also no longer drawn when the logs are structured, decided in the one place every caller passes through rather than by each of them. It paints with carriage returns and escape sequences, which have no business in a stream something else is meant to parse, and until now a terminal got a bar regardless of log format: running with JSON logs on a terminal put 98 bar lines into the JSON stream. Following a detached operation now also asks whether it is writing to a terminal, instead of assuming it is.

What this does not fix is an unrelated process writing to the same terminal, which is what the issue's example showed. Nothing inside this process can coordinate that.

Verified two ways. A test paints a real bar, logs a real record, repaints, and renders the transcript through a small screen that implements carriage return, newline and the erase sequence, so it judges what a person would have seen rather than that a function was called. It has a control case asserting the collision still happens without the erase, so it fails if the fix is removed. And on a real cluster, with a build that logs every two seconds during the transfer: on main, 20 of 25 records were glued onto a bar frame; with this change, 0 of 24.
