### PR TITLE
fix: let the demo workflow record in its own container

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -42,12 +42,6 @@ jobs:
           # renovate: depName=kubernetes-sigs/kind datasource=github-releases
           version: v0.32.0
 
-      - name: Build the binary the recording drives
-        run: go build -o dist/demo/pv-migrate ./cmd/pv-migrate
-
-      - name: Create the demo fixtures
-        run: task demo:fixtures
-
       # The recording steps live in the Taskfile, the same ones a maintainer
       # runs locally. Only the recorder differs. VHS runs from its own image
       # rather than being installed on the runner, because that image carries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ Things worth knowing before changing them:
 - The transfer needs to be worth watching. Uniform file sizes keep the progress bar moving at a steady rate, and the destination is emptied first, since rsync copies only what differs and a second run against a full destination is over before the bar moves.
 - Both tapes pin a strategy. Left alone the ladder picks the mount strategy, which copies locally in a second or two and is too fast to see. The failure tape pins mount for the opposite reason, to keep that recording short, and doing so assumes one pod can mount both claims. On a cluster that provisions them in different zones the strategy declines instead, and the recording shows the wrong failure.
 - The workflow runs the same steps as the local task, from the same tapes. Only the recorder differs. CI runs VHS from its own image, whose fonts include the colour emoji this tool prints and which a bare runner may not have.
+- That image also brings its own locale and fonts, and both matter. Without a UTF-8 locale the shell mangles the prompt the tapes wait for, and a missing font is substituted silently, which moves every wrap point. The tapes therefore set the locale and name the font instead of relying on the recorder's defaults, and recording by hand on a machine without that font produces a picture that wraps differently.
 
 Regenerate them by hand or by dispatching the workflow, never on a schedule.
 Every run brings its own timestamps and generated names, so a periodic re-record would commit another megabyte of GIF showing nothing new.

--- a/demo/common.tape
+++ b/demo/common.tape
@@ -9,6 +9,18 @@
 # the terminal in the picture matches the page around it.
 
 Set Shell "bash"
+
+# The recorder's own image sets no locale, and without one the shell mangles
+# anything outside ASCII: the prompt below arrives as ">" rather than "❯", and
+# a tape waiting for it waits forever. Set here rather than in the workflow so
+# that a recording made anywhere is made the same way. LC_ALL alone, since it
+# outranks every other locale variable.
+Env LC_ALL C.UTF-8
+# Named rather than left to the default, because the recorder falls back
+# silently when a font is missing and the recording then wraps at a different
+# column. The workflow's image carries this one; a machine recording by hand
+# needs it installed to produce the same picture.
+Set FontFamily "JetBrains Mono"
 Set FontSize 36
 Set Width 2800
 Set Height 1240


### PR DESCRIPTION
The first dispatch of the demo workflow failed, in [run 30702779573](https://github.com/utkuozdemir/pv-migrate/actions/runs/30702779573). It waited five minutes for the shell prompt to come back and gave up:

```
Wait 5m Line ^\x{276f}\s*$
failed to execute command: timeout waiting for "Line ^\x{276f}\s*$" to match ^\x{276f}\s*$; last value was: >
```

The tapes type `PS1='❯ '` and then wait for that prompt, which is what keeps a tape from stopping while the migration is still running. The recorder's image sets no locale at all, `LANG` and `LC_ALL` are both empty there, so the shell mangled the character and what came back was a plain `>`. Reproduced in the same image, and fixed by setting a UTF-8 locale, after which the prompt renders as `❯` and the recording completes.

The locale is set in the shared tape settings rather than in the workflow, so a recording made anywhere is made the same way.

Two other things came out of verifying it.

The tapes now name the font. VHS substitutes a missing font silently, and the substitute moves every wrap point, so a recording made by hand on a machine without JetBrains Mono does not match one the workflow makes. Naming it does not change what the workflow produces, since that was already the recorder's default and the image ships it, but it makes the requirement visible instead of silent. AGENTS.md says so too.

The workflow also lost the two steps that built the binary and created the fixtures, because `task demo:record` already does both. What recording means is described in one place again.

Verified by running the real tape through `ghcr.io/charmbracelet/vhs:v0.11.0` against a cluster, which is what CI does: it completes, the emoji and the prompt render, and the migration in the recording succeeds. The two committed GIFs are untouched, confirmed by hash.

One thing to know before dispatching: the recordings in the README were made on a machine without JetBrains Mono, so the first successful run will propose images that wrap at different columns. That is what the pull request it opens is for. If you would rather they match, installing the font locally and re-recording once would settle it.
