### PR TITLE
fix: stop a message's emoji from painting over its first word

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,8 @@ Things that have bitten before:
   A signature does not survive the rebase or squash that lands a change here, so requiring one buys nothing and puts a hardware key in the way of routine work.
   Do not add `-S`, and do not leave a pull request in draft on account of a commit being unsigned.
 - Nothing carries AI attribution: no "generated with" lines, no AI co-author trailers, in commits, pull requests or anywhere else.
+- Log messages open with an emoji, and it has to be one a terminal gives two columns to, which is not every emoji that looks like one.
+  A test walks the source and rejects the narrow ones, with the reasoning in its comment; warnings all use the same marker, so pick that one rather than a new shade of orange.
 - Linting is `golangci-lint` with linters enabled by default and a short, individually-justified disable list.
   New code is expected to satisfy it rather than accumulate suppressions, and a complexity finding is usually telling you to extract a function.
 - Dependencies are updated by Renovate; `.renovaterc.json` is the authority on what qualifies.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lmittmann/tint v1.2.0
 	github.com/mattn/go-isatty v0.0.24
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/neilotoole/slogt/v2 v2.0.0
+	github.com/rivo/uniseg v0.4.7
 	github.com/schollz/progressbar/v3 v3.19.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -89,7 +91,6 @@ require (
 	github.com/lib/pq v1.12.3 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
-	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
@@ -104,7 +105,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/internal/bucketstorage/bucketstorage.go
+++ b/internal/bucketstorage/bucketstorage.go
@@ -501,9 +501,9 @@ func mergeHelmValues(baseValues map[string]any, req *Request, logger *slog.Logge
 	merged := loader.MergeMaps(baseValues, userValues)
 
 	if req.ImageTag != "" {
-		logger.Info("🏷️ Using image tag", "tag", req.ImageTag)
+		logger.Info("🔖 Using image tag", "tag", req.ImageTag)
 	} else {
-		logger.Info("🏷️ Using chart default image tags")
+		logger.Info("🔖 Using chart default image tags")
 	}
 
 	return merged, nil

--- a/internal/console/emojiwidth_test.go
+++ b/internal/console/emojiwidth_test.go
@@ -1,0 +1,173 @@
+package console_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// variationSelector asks for the emoji form of a character that is otherwise
+// drawn as text. Its presence in a marker is the whole bug: the terminal still
+// measures the character it was applied to, which is one column, while the font
+// paints the two column picture that was asked for.
+const variationSelector = '️'
+
+// TestEmojiPrefixesAreTwoColumnsWide walks every message in the repository that
+// starts with an emoji and checks the terminal will give that emoji two columns.
+//
+// A terminal decides how wide a character is from its East Asian Width property
+// rather than from what the font draws, so an emoji that is only an emoji by
+// request spills over the space after it and lands on the first letter of the
+// message.
+//
+// The fix is to use emoji that are wide in their own right, which is what this
+// checks, because the alternative, padding the narrow ones with a second space,
+// is invisible in the source and renders wrong in terminals that do measure the
+// variation selector.
+func TestEmojiPrefixesAreTwoColumnsWide(t *testing.T) {
+	t.Parallel()
+
+	// The package level width functions consult the process locale, where an
+	// East Asian one calls ambiguous characters two columns wide. Ask for one
+	// answer instead, since neither the recordings nor most users are there.
+	widths := runewidth.NewCondition()
+	widths.EastAsianWidth = false
+
+	root := repoRoot(t)
+	checked := 0
+
+	for _, path := range trackedGoFiles(t, root) {
+		checked += checkFile(t, widths, root, path)
+	}
+
+	assert.Positive(t, checked, "the walk found no emoji at all, so it is checking nothing")
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+
+	return root
+}
+
+// trackedGoFiles lists what the repository actually contains, rather than what
+// happens to be sitting in the checkout. A scratch file that does not parse, or
+// a worktree left underneath the repository by other work, would otherwise fail
+// this test for reasons that have nothing to do with the branch under test.
+func trackedGoFiles(t *testing.T, root string) []string {
+	t.Helper()
+
+	listed, err := exec.CommandContext(t.Context(), "git", "-C", root, "ls-files", "-z", "*.go").Output()
+	require.NoError(t, err)
+
+	paths := strings.FieldsFunc(string(listed), func(r rune) bool { return r == 0 })
+	require.NotEmpty(t, paths)
+
+	return paths
+}
+
+// checkFile reports how many emoji-prefixed literals it looked at.
+func checkFile(t *testing.T, widths *runewidth.Condition, root, path string) int {
+	t.Helper()
+
+	file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(root, path), nil, 0)
+	require.NoError(t, err)
+
+	found := 0
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		literal, ok := node.(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+
+		text, err := strconv.Unquote(literal.Value)
+		if err != nil {
+			return true
+		}
+
+		prefix, ok := emojiPrefix(text)
+		if !ok {
+			return true
+		}
+
+		found++
+
+		assert.Equal(t, 2, widths.StringWidth(prefix),
+			"%s: %q leads with %q, which a terminal gives %d column(s), so the emoji paints over the text after it",
+			path, text, prefix, widths.StringWidth(prefix))
+
+		return true
+	})
+
+	return found
+}
+
+// emojiPrefix returns the leading grapheme cluster of a string when that cluster
+// is an emoji. Taking the whole cluster matters: an emoji is often several code
+// points, and only the cluster as a whole has a width.
+func emojiPrefix(text string) (string, bool) {
+	if text == "" {
+		return "", false
+	}
+
+	graphemes := uniseg.NewGraphemes(text)
+	if !graphemes.Next() {
+		return "", false
+	}
+
+	cluster := graphemes.Str()
+	if !isEmoji(cluster) {
+		return "", false
+	}
+
+	return cluster, true
+}
+
+// isEmoji reports whether a grapheme cluster is one of the pictures this project
+// uses to mark a log message.
+//
+// A cluster asking for the emoji form of a character counts however that
+// character is encoded, which is what catches a marker whose base is an ordinary
+// symbol, a digit or a letter. Beyond those it is a short list of blocks rather
+// than the full emoji property, since the standard library carries no table for
+// that and the point is to catch the marker at the front of a message, not to
+// classify text. A picture drawn from a block not listed here, and not asking
+// for the emoji form, goes unchecked, and so does one buried mid-message.
+//
+// The list does hold characters that are narrow on purpose and stay that way,
+// the tick and the cross among them. Opening a message with one is reported,
+// which is the answer this project wants: every message here opens with a
+// picture, and one that arrives as flat text beside the rest is the thing being
+// prevented.
+func isEmoji(cluster string) bool {
+	if strings.ContainsRune(cluster, variationSelector) {
+		return true
+	}
+
+	return unicode.Is(emojiBlocks, []rune(cluster)[0])
+}
+
+var emojiBlocks = &unicode.RangeTable{
+	R16: []unicode.Range16{
+		{Lo: 0x231A, Hi: 0x23FF, Stride: 1}, // watches, hourglasses, media controls
+		{Lo: 0x2600, Hi: 0x27BF, Stride: 1}, // miscellaneous symbols and dingbats
+		{Lo: 0x2B00, Hi: 0x2BFF, Stride: 1}, // arrows, stars and geometric shapes
+	},
+	R32: []unicode.Range32{
+		{Lo: 0x1F000, Hi: 0x1FAFF, Stride: 1}, // the emoji planes proper
+	},
+}

--- a/internal/k8s/job.go
+++ b/internal/k8s/job.go
@@ -382,7 +382,7 @@ func writeFailureTail(
 	}
 
 	if structuredLogs {
-		logger.Warn("🗒 Last log lines of the failed job pod", "pod", pod.Namespace+"/"+pod.Name, "tail", tail)
+		logger.Warn("📝 Last log lines of the failed job pod", "pod", pod.Namespace+"/"+pod.Name, "tail", tail)
 
 		return
 	}

--- a/internal/strategy/local.go
+++ b/internal/strategy/local.go
@@ -35,7 +35,7 @@ func (r *Local) Run(ctx context.Context, attempt *migration.Attempt, logger *slo
 	}
 
 	if hasHelmOverrides(req) {
-		logger.Warn("⚠️  Local strategy does not deploy an rsync Job; " +
+		logger.Warn("🔶 Local strategy does not deploy an rsync Job; " +
 			"rsync-related Helm values (e.g. rsync.*) will have no effect")
 	}
 

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -241,9 +241,9 @@ func getMergedHelmValues(
 	merged := loader.MergeMaps(baseValues, userValues)
 
 	if request.ImageTag != "" {
-		logger.Info("🏷️ Using image tag", "tag", request.ImageTag)
+		logger.Info("🔖 Using image tag", "tag", request.ImageTag)
 	} else {
-		logger.Info("🏷️ Using chart default image tags")
+		logger.Info("🔖 Using chart default image tags")
 	}
 
 	return merged, nil


### PR DESCRIPTION
A terminal decides how many columns a character occupies from its East Asian Width property rather than from what the font draws. An emoji that defaults to text presentation, and only becomes a picture through a variation selector, counts as one column there while the font paints two, so the glyph spills over the space after it and lands on the first letter of the message. Three markers were in that state, one of which had already been patched by hand with a second space.

They are replaced with emoji that are wide in their own right, and the local strategy's warning now carries the same marker as every other warning rather than one of its own. A test walks the source and rejects any message whose leading emoji would be given a single column, so a narrow one cannot come back unnoticed.