### PR TITLE
chore: give the recorded demo text more weight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,9 +191,12 @@ Things worth knowing before changing them:
 - The workflow runs the same steps as the local task, from the same tapes. Only the recorder differs. CI runs VHS from its own image, whose fonts include the colour emoji this tool prints and which a bare runner may not have.
 - The recorder honours a setting only where nothing precedes it, and otherwise warns and carries on with its own defaults, so a tape can record at the wrong size and colours while reporting success. The settings therefore come first in every tape, anything that is not a setting comes after them, and `task demo:record` fails on that warning rather than leaving it to be noticed.
 - That image also brings its own locale and fonts, and both matter. Without a UTF-8 locale the shell mangles the prompt the tapes wait for, and a missing font is substituted silently, which moves every wrap point. The tapes therefore set the locale and name the font instead of relying on the recorder's defaults, and recording by hand on a machine without that font produces a picture that wraps differently.
+- The font weight is carried in the family name, because the recorder sets a family and a size and nothing else. Matching what GitHub renders is not available: its stack resolves to a font that ships with macOS and not with the recorder's image, and the one member of that stack the image does carry is lighter still.
 
 Regenerate them by hand or by dispatching the workflow, never on a schedule.
 Every run brings its own timestamps and generated names, so a periodic re-record would commit another megabyte of GIF showing nothing new.
+Dispatching it against a branch rather than the default one records from that branch's code and proposes the recordings back into it, which is how a change to a tape arrives together with the picture it produces.
+Doing that on a change to how the recordings are made is deliberate rather than automatic: recording on every push would spend a cluster on each intermediate attempt, and the commit it pushed back would land without checks and race the next push.
 
 ## Building and releasing
 

--- a/demo/common.tape
+++ b/demo/common.tape
@@ -14,7 +14,14 @@ Set Shell "bash"
 # silently when a font is missing and the recording then wraps at a different
 # column. The workflow's image carries this one; a machine recording by hand
 # needs it installed to produce the same picture.
-Set FontFamily "JetBrains Mono"
+#
+# The weight is part of the family name because the recorder has no setting for
+# it, only a family and a size. At the regular weight the text came out thin
+# against the dark background, and matching what GitHub itself renders is not an
+# option: its font stack resolves to SF Mono on a Mac, which does not exist in
+# the recorder's image, and the one member of that stack the image does carry
+# paints even less ink than this family does.
+Set FontFamily "JetBrains Mono SemiBold"
 Set FontSize 36
 Set Width 2800
 Set Height 1240


### PR DESCRIPTION
The text in the two README recordings came out thin against the dark background. The recorder takes a font family and a size and has nothing else, so the weight now travels in the family name.

Matching the font a browser uses for the page around the image is not available: that stack resolves to a face shipped with macOS rather than with the recorder's image, and the one member of it the image does carry paints less ink than the family already in use. The chosen weight was picked by measuring how much of the rendered text is bright, across every weight the image offers, rather than by eye.

The recordings themselves are left alone here, to be regenerated once rather than committed twice.