### PR TITLE
docs: record how a partly published release is finished

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,10 @@ Things that have bitten before:
 - goreleaser already strips binaries and stamps the version by default. Setting `ldflags` at all silently replaces those defaults, so the binary would report version `dev`, and the image tag and chart version are derived from that string.
 - A snapshot or dev build deliberately produces an *empty* image tag rather than a wrong one, which makes the chart fall back to its own default. That is why the version string is inspected rather than used directly.
 - CI runs a goreleaser snapshot on every change, which validates the packaging inputs before release day rather than during it.
+- A release that fails after its archives are uploaded is finished by tagging the next patch version, never by re-running it over the top.
+  The package managers pin the archives by checksum, and the archives are not built reproducibly, so replacing one silently invalidates a hash somebody has already recorded.
+  This is why a published release is left exactly as it went out, even when a later stage of the same run failed.
+- The package manager updates are the last stage, after the release and the images, so a credential that lapsed since the previous release takes down only those, and it does so on a release that otherwise looks complete.
 
 ## Conventions
 


### PR DESCRIPTION
A release that fails after its archives are uploaded cannot be finished by running it again, because the upload comes before the package managers are updated and an archive that is already there is refused. Replacing it instead would be worse: the package managers pin an archive by checksum, the archives are not built reproducibly, and a replacement therefore invalidates a hash somebody may already have recorded. So a published release is left exactly as it went out, and the next patch version carries the parts that did not make it.

Also noted is why this failure looks like nothing at all: the package manager updates are the last stage, after the release and the images, so a credential that lapsed since the previous release takes down only those, on a release that otherwise appears complete.