### PR TITLE
docs: install the Homebrew cask by its fully qualified name

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ See [Bucket backup and restore](docs/backup-restore.md) for the backends, the ob
 ## Installation
 
 See [docs/install.md](docs/install.md) for the install options (Homebrew, krew, Scoop, release archives, Docker) and shell completion.
+The shortest one:
+
+```bash
+brew install utkuozdemir/pv-migrate/pv-migrate
+```
 
 The artifacts live here:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,11 +14,13 @@ Pick whichever of the options below fits your machine, they all install the same
 ## Homebrew (macOS and Linux)
 
 ```bash
-brew tap utkuozdemir/pv-migrate
-brew install pv-migrate
+brew install utkuozdemir/pv-migrate/pv-migrate
 ```
 
-The tap installs the binary and the completions for bash, zsh and fish.
+The fully qualified name is required.
+Homebrew loads a cask from a non-official tap only when it is trusted, and installing the cask by its full name trusts exactly this cask.
+
+The cask installs the binary and the completions for bash, zsh and fish.
 Upgrades come with `brew upgrade`.
 
 ## krew


### PR DESCRIPTION
Homebrew loads a cask from a non-official tap only when it is trusted, and installing the cask by its fully qualified name trusts exactly that cask. The documented steps, tapping the repository and installing by the short name, are refused. The install guide and the README now give the fully qualified command.

Signed-off-by: Utku Ozdemir <utkuozdemir@gmail.com>