### PR TITLE
chore: post the Codecov comment only when coverage changes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,5 @@ coverage:
     project:
       default:
         informational: true
+comment:
+  require_changes: true


### PR DESCRIPTION
Codecov commented on every pull request, including ones that touch no coverable line, and each comment arrives as an email. The comment is now posted only when the change moves coverage, which is the one case where it says something the status checks do not already show.

The status checks are unchanged and still link to the full report on every pull request.
