### PR TITLE
feat: fall back to the node port when the load balancer gets no address

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,10 @@ So there is a ladder of strategies, tried in order, each of which declines the j
   Adding a strategy therefore means being precise about which of those two a given condition is, because getting it wrong turns a real failure into a silent fallback.
 - Order is the user's, and the default order is cheapest-first.
   Mounting both volumes in one pod needs no network at all, so it comes first; everything after it is rsync over SSH and differs only in how the two sides find each other.
+- A strategy carries its own fallback where the fallback is free.
+  A `LoadBalancer` Service also has a node port, so when no address arrives in time the `loadbalancer` strategy uses that node port instead of failing, and a cluster without a load balancer controller still gets a transfer with the default order.
+  For the same reason Helm is not asked to wait for such a release: its wait blocks on the address, which the strategy waits for itself, with a budget.
+  A release Helm does not wait for has no readiness gate at all, so the install waits for the sshd pod to become ready itself, with the install budget, right where it decides to skip Helm's wait.
 - The SSH key pair is generated per attempt and never reused.
   It exists for one transfer and is thrown away with the release.
 - Two strategies are opt-in because they have costs the others do not: one depends on node reachability, and one routes the whole transfer through the machine running the CLI.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -38,7 +38,7 @@ Flags:
       --id string                       Custom operation ID (lowercase alphanumeric with optional hyphens, max 24 chars). If not set, a random ID is generated. Used to identify the operation in 'status' and 'cleanup' commands
   -i, --ignore-mounted                  Do not fail if the source or destination PVC is mounted
       --ignore-sizes                    Do not fail if the destination PVC is smaller than the source PVC
-      --loadbalancer-timeout duration   Timeout for the load balancer to receive an external IP. Only used by the loadbalancer strategy (default 2m0s)
+      --loadbalancer-timeout duration   Time to wait for the load balancer to receive an address before the loadbalancer strategy falls back to the Service's node port (default 2m0s)
       --log-format string               Log format, one of text, json (default "text")
       --log-level string                Log level, one of DEBUG, INFO, WARN, ERROR or an slog-parseable level: https://pkg.go.dev/log/slog#Level.UnmarshalText (default "INFO")
   -o, --no-chown                        Omit chown during rsync

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -16,7 +16,7 @@ The default order is cheapest first, and `--strategies` overrides it.
 | --- | --- |
 | `mount` | Mounts both PVCs in a single pod and runs rsync locally, without SSH or networking. Only applies when both PVCs are in the same namespace and can be mounted by one pod. |
 | `clusterip` | rsync over SSH through a `ClusterIP` Service. Only applies when both PVCs are in the same cluster. |
-| `loadbalancer` | rsync over SSH through a `LoadBalancer` Service. Works across clusters when the load balancer address is reachable from the other side. |
+| `loadbalancer` | rsync over SSH through a `LoadBalancer` Service. Works across clusters when the load balancer address is reachable from the other side. When no address arrives within `--loadbalancer-timeout`, e.g., on a cluster without a load balancer controller, it falls back to the Service's node port on the sshd pod's node, which is what the `nodeport` strategy would use, and which needs that node to be reachable from the other side. |
 | `nodeport` | rsync over SSH through a `NodePort` Service. Opt-in, because it depends on the nodes being reachable. The port can be fixed with `--helm-set sshd.service.nodePort=<port>`. |
 | `local` | Runs sshd on both sides and tunnels the traffic through the machine running the CLI, with Kubernetes port-forwarding and an SSH reverse tunnel. Opt-in, for restricted clusters, and recommended for smaller transfers only, since all data goes through your machine. |
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -124,6 +124,11 @@ func TestMigrate(t *testing.T) {
 		te := setupExtraCluster(t, si)
 		testLoadBalancer(t, te)
 	})
+	t.Run("LoadBalancerNodePortFallback", func(t *testing.T) {
+		t.Parallel()
+		te := setupExtraCluster(t, si)
+		testLoadBalancerNodePortFallback(t, te)
+	})
 	t.Run("NoChown", func(t *testing.T) {
 		t.Parallel()
 		te := setupSameNS(t, si)
@@ -717,6 +722,30 @@ func testNodePort(t *testing.T, te *testEnv) {
 	// Verify that the extra file still exists (no deletion)
 	_, err = execInPod(ctx, te.destCli, te.destNS, "dest", checkExtraDataShellCommand)
 	require.NoError(t, err)
+}
+
+// testLoadBalancerNodePortFallback runs the loadbalancer strategy against a
+// Service no load balancer controller will ever pick up, by giving it a load
+// balancer class nothing implements, so the address never arrives and the
+// strategy has to fall back to the Service's node port.
+//
+//nolint:thelper
+func testLoadBalancerNodePortFallback(t *testing.T, te *testEnv) {
+	ctx := t.Context()
+
+	cmd := fmt.Sprintf("%s -K %s -s loadbalancer --loadbalancer-timeout 15s"+
+		" --helm-set sshd.service.loadBalancerClass=pv-migrate.test/none -i -n %s -N %s --source source --dest dest",
+		defaultHelmArgs(t), te.shared.extraKubeconfig, te.sourceNS, te.destNS)
+	require.NoError(t, runCliApp(ctx, t, cmd))
+
+	stdout, err := execInPod(ctx, te.destCli, te.destNS, "dest", printDataUIDGIDContentShellCommand)
+	require.NoError(t, err)
+
+	parts := strings.Split(stdout, "\n")
+	require.Len(t, parts, 3)
+	assert.Equal(t, dataFileUID, parts[0])
+	assert.Equal(t, dataFileGID, parts[1])
+	assert.Equal(t, generateDataContent, parts[2])
 }
 
 // testNodePortDestHostOverride tests the NodePort strategy with a custom destination host override.

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -337,7 +337,8 @@ func setMigrateCmdFlags(cmd *cobra.Command, options *Options, logLevels, logForm
 		FlagLoadBalancerTimeout,
 		migration.LoadBalancerTimeout,
 		fmt.Sprintf(
-			"Timeout for the load balancer to receive an external IP. Only used by the %s strategy",
+			"Time to wait for the load balancer to receive an address before the %s strategy "+
+				"falls back to the Service's node port",
 			pvmigrate.LoadBalancer,
 		),
 	)

--- a/internal/helm/pv-migrate/README.md
+++ b/internal/helm/pv-migrate/README.md
@@ -116,7 +116,7 @@ The helm chart of pv-migrate
 | sshd.service.annotations | object | `{}` | SSHD service annotations |
 | sshd.service.loadBalancerClass | string | `""` | SSHD service load balancer class |
 | sshd.service.loadBalancerIP | string | `""` | SSHD service load balancer IP |
-| sshd.service.nodePort | string | `nil` | SSHD service node port (only used when type is NodePort) |
+| sshd.service.nodePort | string | `nil` | SSHD service node port (only used when type is NodePort or LoadBalancer) |
 | sshd.service.port | int | `22` | SSHD service port |
 | sshd.service.type | string | `"ClusterIP"` | SSHD service type |
 | sshd.serviceAccount.annotations | object | `{}` | SSHD service account annotations |

--- a/internal/helm/pv-migrate/templates/sshd/service.yaml
+++ b/internal/helm/pv-migrate/templates/sshd/service.yaml
@@ -24,7 +24,7 @@ spec:
       targetPort: {{ .Values.sshd.containerPort }}
       protocol: TCP
       name: ssh
-      {{- if and (eq .Values.sshd.service.type "NodePort") .Values.sshd.service.nodePort }}
+      {{- if and (or (eq .Values.sshd.service.type "NodePort") (eq .Values.sshd.service.type "LoadBalancer")) .Values.sshd.service.nodePort }}
       nodePort: {{ .Values.sshd.service.nodePort }}
       {{- end }}
   selector:

--- a/internal/helm/pv-migrate/values.yaml
+++ b/internal/helm/pv-migrate/values.yaml
@@ -40,7 +40,7 @@ sshd:
     type: ClusterIP
     # -- SSHD service port
     port: 22
-    # -- SSHD service node port (only used when type is NodePort)
+    # -- SSHD service node port (only used when type is NodePort or LoadBalancer)
     nodePort:
     # -- SSHD service annotations
     annotations: {}

--- a/internal/helm/render_test.go
+++ b/internal/helm/render_test.go
@@ -210,3 +210,22 @@ func component(name string, extra map[string]any) map[string]any {
 
 	return map[string]any{name: section}
 }
+
+// TestNodePortPinAppliesToLoadBalancerService pins that a fixed node port is
+// honored for a LoadBalancer Service as well, since the loadbalancer strategy
+// falls back to that port.
+func TestNodePortPinAppliesToLoadBalancerService(t *testing.T) {
+	t.Parallel()
+
+	rendered := render(t, map[string]any{
+		"sshd": map[string]any{
+			"enabled":   true,
+			"namespace": "default",
+			"publicKey": "ssh-ed25519 AAAA",
+			"pvcMounts": []any{map[string]any{"name": "pvc", "mountPath": "/source"}},
+			"service":   map[string]any{"type": "LoadBalancer", "nodePort": 30555},
+		},
+	})
+
+	assert.Contains(t, rendered["pv-migrate/templates/sshd/service.yaml"], "nodePort: 30555")
+}

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -22,8 +22,43 @@ const (
 	podWatchTimeout = 2 * time.Minute
 )
 
+// WaitForPod waits until a pod matching the selector has left the Pending phase.
 func WaitForPod(
 	ctx context.Context, cli kubernetes.Interface, ns, labelSelector string, logger *slog.Logger,
+) (*corev1.Pod, error) {
+	return waitForPod(ctx, cli, ns, labelSelector, podWatchTimeout, podStarted, logger)
+}
+
+// WaitForPodReady waits until a pod matching the selector reports the Ready
+// condition, within the given budget. It is what a caller uses in place of
+// Helm's own wait for a release, so the budget is the caller's install timeout.
+func WaitForPodReady(
+	ctx context.Context, cli kubernetes.Interface, ns, labelSelector string, timeout time.Duration, logger *slog.Logger,
+) (*corev1.Pod, error) {
+	return waitForPod(ctx, cli, ns, labelSelector, timeout, podReady, logger)
+}
+
+func podStarted(pod *corev1.Pod) bool {
+	return pod.Status.Phase != corev1.PodPending
+}
+
+func podReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+func waitForPod(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	ns, labelSelector string,
+	timeout time.Duration,
+	done func(*corev1.Pod) bool,
+	logger *slog.Logger,
 ) (*corev1.Pod, error) {
 	var result *corev1.Pod
 
@@ -34,7 +69,7 @@ func WaitForPod(
 
 	resCli := cli.CoreV1().Pods(ns)
 
-	ctx, cancel := context.WithTimeout(ctx, podWatchTimeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	listWatch := podLabelListWatch(resCli, labelSelector)
@@ -55,7 +90,7 @@ func WaitForPod(
 			logger.Warn("🔶 Pod is not starting yet", "pod", res.Name, "waiting", waiting)
 		}
 
-		if res.Status.Phase != corev1.PodPending {
+		if done(res) {
 			result = res
 
 			return true, nil
@@ -68,8 +103,8 @@ func WaitForPod(
 		// The bare watch error says "timed out waiting for the condition" and
 		// names neither the wait nor its budget.
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("timed out after %s waiting for a pod (selector %s) to start: %w",
-				podWatchTimeout, labelSelector, err)
+			return nil, fmt.Errorf("timed out after %s waiting for a pod (selector %s): %w",
+				timeout, labelSelector, err)
 		}
 
 		return nil, fmt.Errorf("failed to wait for pod: %w", err)

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -1,0 +1,45 @@
+package k8s_test
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/utkuozdemir/pv-migrate/internal/k8s"
+)
+
+// Not parallel: the feature gate is process-wide. The streaming list the
+// reflector prefers is not served by the fake clientset.
+//
+//nolint:paralleltest
+func TestWaitForPodReady(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	pod := func(ready corev1.ConditionStatus) *corev1.Pod {
+		return &corev1.Pod{
+			Namespace: "ns", Name: "sshd-1", Labels: map[string]string{"app": "sshd"},
+			Status: corev1.PodStatus{
+				Phase:      corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: ready}},
+			},
+		}
+	}
+
+	got, err := k8s.WaitForPodReady(t.Context(), fake.NewClientset(pod(corev1.ConditionTrue)), "ns", "app=sshd",
+		time.Minute, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	assert.Equal(t, "sshd-1", got.Name)
+
+	_, err = k8s.WaitForPodReady(t.Context(), fake.NewClientset(pod(corev1.ConditionFalse)), "ns", "app=sshd",
+		20*time.Millisecond, slog.New(slog.DiscardHandler))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out after 20ms",
+		"a pod that is Running but not Ready is not done, and the error names the budget")
+}

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -85,7 +85,8 @@ func GetServiceAddress(
 	return result, nil
 }
 
-// GetNodePort waits for a NodePort service to be ready and returns its assigned port.
+// GetNodePort waits for a Service that carries a node port, of type NodePort or
+// LoadBalancer, and returns the port allocated for ssh.
 func GetNodePort(
 	ctx context.Context,
 	cli kubernetes.Interface,
@@ -137,7 +138,7 @@ func GetAnyNodeIP(ctx context.Context, cli kubernetes.Interface) (string, error)
 	return "", errors.New("no node with a usable IP address found")
 }
 
-// waitForNodePortService waits for a NodePort service to be ready.
+// waitForNodePortService waits for a Service that carries a node port.
 func waitForNodePortService(ctx context.Context, cli kubernetes.Interface, ns, name string) (*corev1.Service, error) {
 	resCli := cli.CoreV1().Services(ns)
 	fieldSelector := fields.OneTermEqualSelector(metav1.ObjectNameField, name).String()
@@ -174,8 +175,8 @@ func waitForNodePortService(ctx context.Context, cli kubernetes.Interface, ns, n
 				return false, fmt.Errorf("unexpected type while watching service: %s/%s", ns, name)
 			}
 
-			if svc.Spec.Type != corev1.ServiceTypeNodePort {
-				return false, fmt.Errorf("service %s/%s is not of type NodePort", ns, name)
+			if svc.Spec.Type != corev1.ServiceTypeNodePort && svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+				return false, fmt.Errorf("service %s/%s is of type %s and has no node port", ns, name, svc.Spec.Type)
 			}
 
 			resultSvc = svc
@@ -188,19 +189,27 @@ func waitForNodePortService(ctx context.Context, cli kubernetes.Interface, ns, n
 	return resultSvc, nil
 }
 
-// findNodePort extracts the NodePort from a service.
+// findNodePort extracts the node port for ssh from a Service, or the first
+// port's. A LoadBalancer Service can be created without node ports, and then
+// there is nothing to connect to.
 func findNodePort(svc *corev1.Service) (int, error) {
 	if len(svc.Spec.Ports) == 0 {
 		return 0, errors.New("service has no ports defined")
 	}
 
-	// First try to find SSH port
-	for _, port := range svc.Spec.Ports {
-		if port.Name == "ssh" || port.Port == 22 {
-			return int(port.NodePort), nil
+	port := svc.Spec.Ports[0]
+
+	for _, candidate := range svc.Spec.Ports {
+		if candidate.Name == "ssh" || candidate.Port == 22 {
+			port = candidate
+
+			break
 		}
 	}
 
-	// Fallback to the first port
-	return int(svc.Spec.Ports[0].NodePort), nil
+	if port.NodePort == 0 {
+		return 0, fmt.Errorf("service %s/%s has no node port allocated", svc.Namespace, svc.Name)
+	}
+
+	return int(port.NodePort), nil
 }

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -2,10 +2,13 @@ package k8s
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -180,4 +183,52 @@ func TestGetAnyNodeIP(t *testing.T) {
 	ip, err := GetAnyNodeIP(ctx, mixed)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.1", ip)
+}
+
+// A LoadBalancer Service carries a node port too, and the loadbalancer strategy
+// falls back to it, so the lookup accepts that type. One created without node
+// ports is an error rather than port zero.
+//
+// Not parallel: the feature gate is process-wide. The streaming list the
+// reflector prefers is not served by the fake clientset.
+//
+//nolint:paralleltest
+func TestGetNodePortOfLoadBalancerService(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	withPort := &corev1.Service{
+		Namespace: "ns", Name: "with-port",
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Name: "ssh", Port: 22, NodePort: 31234}},
+		},
+	}
+	withoutPort := &corev1.Service{
+		Namespace: "ns", Name: "without-port",
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Name: "ssh", Port: 22}},
+		},
+	}
+	clusterIP := &corev1.Service{
+		Namespace: "ns", Name: "cluster-ip",
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Name: "ssh", Port: 22}},
+		},
+	}
+
+	// One client per Service: the fake clientset does not apply the field
+	// selector the lookup watches with, so a shared one would deliver them all.
+	port, err := GetNodePort(t.Context(), fake.NewClientset(withPort), "ns", "with-port", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 31234, port)
+
+	_, err = GetNodePort(t.Context(), fake.NewClientset(withoutPort), "ns", "without-port", time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no node port allocated")
+
+	_, err = GetNodePort(t.Context(), fake.NewClientset(clusterIP), "ns", "cluster-ip", time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no node port")
 }

--- a/internal/strategy/loadbalancer.go
+++ b/internal/strategy/loadbalancer.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/utkuozdemir/pv-migrate/internal/k8s"
 	"github.com/utkuozdemir/pv-migrate/internal/migration"
 	"github.com/utkuozdemir/pv-migrate/internal/util"
@@ -16,27 +18,54 @@ func (r *LoadBalancer) Run(ctx context.Context, attempt *migration.Attempt, logg
 	return runTwoReleaseStrategy(ctx, attempt, "LoadBalancer", resolveLBTarget, logger)
 }
 
+// resolveLBTarget waits for the load balancer's address and, when none arrives
+// within the budget, falls back to the node port the same Service carries. A
+// cluster without a load balancer controller leaves the Service pending
+// forever, and before this fallback that was the end of the default order.
 func resolveLBTarget(
 	ctx context.Context,
 	attempt *migration.Attempt,
 	topo topology,
 	sshdRelease string,
-	_ *slog.Logger,
+	logger *slog.Logger,
 ) (sshTarget, error) {
+	info := topo.sshd.info
+	req := attempt.Migration.Request
 	svcName := sshdRelease + "-sshd"
 
-	lbAddress, err := k8s.GetServiceAddress(
-		ctx,
-		topo.sshd.info.ClusterClient.KubeClient,
-		topo.sshd.info.Claim.Namespace,
-		svcName,
-		attempt.Migration.Request.LoadBalancerTimeout,
-	)
-	if err != nil {
-		return sshTarget{}, fmt.Errorf("failed to get service address: %w", err)
+	// The address wait retries a failing read until its deadline and then reports
+	// a timeout, whatever the cause was. Reading the Service once first makes an
+	// API problem fail here with its own message, so that only a missing address
+	// falls back.
+	cli := info.ClusterClient.KubeClient
+
+	if _, err := cli.CoreV1().Services(info.Claim.Namespace).Get(ctx, svcName, metav1.GetOptions{}); err != nil {
+		return sshTarget{}, fmt.Errorf("failed to get service %s/%s: %w", info.Claim.Namespace, svcName, err)
 	}
 
-	return sshTarget{host: formatSSHTargetHost(lbAddress)}, nil
+	logger.Info("⏳ Waiting for the load balancer address", "timeout", req.LoadBalancerTimeout)
+
+	lbAddress, err := k8s.GetServiceAddress(ctx, cli, info.Claim.Namespace, svcName, req.LoadBalancerTimeout)
+	if err == nil {
+		return sshTarget{host: formatSSHTargetHost(lbAddress)}, nil
+	}
+
+	// An interrupted run is not a pending load balancer.
+	if ctx.Err() != nil {
+		return sshTarget{}, err
+	}
+
+	logger.Warn("🔶 No load balancer address within --loadbalancer-timeout, falling back to the Service's node port. "+
+		"This is expected on a cluster without a load balancer controller. "+
+		"If yours has one and is just slow, raise the timeout",
+		"timeout", req.LoadBalancerTimeout, "error", err)
+
+	target, fallbackErr := resolveNodePortTarget(ctx, attempt, topo, sshdRelease, logger)
+	if fallbackErr != nil {
+		return sshTarget{}, fmt.Errorf("%w, and the node port fallback failed: %w", err, fallbackErr)
+	}
+
+	return target, nil
 }
 
 // formatSSHTargetHost renders a host for use in rsync's `[user@]host:path`

--- a/internal/strategy/loadbalancer_test.go
+++ b/internal/strategy/loadbalancer_test.go
@@ -1,9 +1,24 @@
 package strategy
 
 import (
+	"errors"
+	"io"
 	"testing"
+	"time"
 
+	"github.com/neilotoole/slogt/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/utkuozdemir/pv-migrate/internal/k8s"
+	"github.com/utkuozdemir/pv-migrate/internal/migration"
+	"github.com/utkuozdemir/pv-migrate/internal/pvc"
 )
 
 func TestFormatSSHTargetHost(t *testing.T) {
@@ -29,4 +44,175 @@ func TestFormatSSHTargetHostIsIdempotent(t *testing.T) {
 		assert.Equal(t, once, formatSSHTargetHost(once),
 			"formatting %q twice must not differ from formatting it once", host)
 	}
+}
+
+// The fixtures below stand in for what the loadbalancer strategy finds after
+// its sshd release is installed: the Service, the sshd pod, and the pod's node.
+
+func lbFixtures(nodePort int32, ingress []corev1.LoadBalancerIngress) (*pvc.Info, *migration.Attempt) {
+	return lbFixturesWithPod(nodePort, ingress, true)
+}
+
+func lbFixturesWithPod(
+	nodePort int32, ingress []corev1.LoadBalancerIngress, podReady bool,
+) (*pvc.Info, *migration.Attempt) {
+	const release = "pv-migrate-test-loadbalancer-src"
+
+	podConditions := []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}}
+	if podReady {
+		podConditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	}
+
+	svc := &corev1.Service{
+		Namespace: "ns", Name: release + "-sshd",
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Name: "ssh", Port: 22, NodePort: nodePort}},
+		},
+		Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: ingress}},
+	}
+	pod := &corev1.Pod{
+		Namespace: "ns",
+		Name:      release + "-sshd-abc12",
+		Labels: map[string]string{
+			"app.kubernetes.io/component": "sshd",
+			"app.kubernetes.io/instance":  release,
+		},
+		Spec:   corev1.PodSpec{NodeName: "worker-1"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: podConditions},
+	}
+	node := &corev1.Node{
+		Name: "worker-1",
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.7"}},
+		},
+	}
+
+	info := &pvc.Info{
+		ClusterClient: &k8s.ClusterClient{KubeClient: fake.NewClientset(svc, pod, node)},
+		Claim:         &corev1.PersistentVolumeClaim{Namespace: "ns", Name: "src"},
+	}
+	attempt := &migration.Attempt{
+		HelmReleaseNamePrefix: "pv-migrate-test-loadbalancer",
+		Migration: &migration.Migration{
+			Request: &migration.Request{
+				HelmTimeout:         time.Minute,
+				LoadBalancerTimeout: 10 * time.Millisecond,
+				Writer:              io.Discard,
+			},
+			SourceInfo: info,
+		},
+	}
+
+	return info, attempt
+}
+
+// Not parallel: the feature gate is process-wide. The streaming list the
+// reflector prefers is not served by the fake clientset.
+//
+//nolint:paralleltest
+func TestResolveLBTarget(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	t.Run("uses the address", func(t *testing.T) {
+		info, attempt := lbFixtures(31234, []corev1.LoadBalancerIngress{{IP: "203.0.113.9"}})
+		topo := topology{sshd: componentSide{info: info}}
+
+		target, err := resolveLBTarget(t.Context(), attempt, topo, attempt.HelmReleaseNamePrefix+"-src", slogt.New(t))
+		require.NoError(t, err)
+
+		assert.Equal(t, sshTarget{host: "203.0.113.9"}, target, "with an address the node port is not used")
+	})
+
+	t.Run("falls back to the node port", func(t *testing.T) {
+		info, attempt := lbFixtures(31234, nil)
+		topo := topology{sshd: componentSide{info: info}}
+
+		target, err := resolveLBTarget(t.Context(), attempt, topo, attempt.HelmReleaseNamePrefix+"-src", slogt.New(t))
+		require.NoError(t, err)
+
+		assert.Equal(t, sshTarget{host: "10.0.0.7", port: 31234}, target,
+			"a pending load balancer falls back to the node port on the sshd pod's node")
+	})
+}
+
+// Not parallel, for the same reason as above.
+//
+//nolint:paralleltest
+func TestResolveLBTarget_Waits(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	t.Run("host override skips the node lookup", func(t *testing.T) {
+		info, attempt := lbFixtures(31234, nil)
+		attempt.Migration.Request.DestHostOverride = "gateway.example.com"
+		topo := topology{sshd: componentSide{info: info}}
+
+		target, err := resolveLBTarget(t.Context(), attempt, topo, attempt.HelmReleaseNamePrefix+"-src", slogt.New(t))
+		require.NoError(t, err)
+
+		assert.Equal(t, sshTarget{port: 31234}, target, "only the port is resolved, the host comes from the override")
+
+		fakeClient, ok := info.ClusterClient.KubeClient.(*fake.Clientset)
+		require.True(t, ok)
+
+		for _, action := range fakeClient.Actions() {
+			assert.NotEqual(t, "nodes", action.GetResource().Resource, "no node is read when the host is given")
+		}
+	})
+
+	t.Run("an API error is not a missing address", func(t *testing.T) {
+		info, attempt := lbFixtures(31234, nil)
+		topo := topology{sshd: componentSide{info: info}}
+
+		fakeClient, ok := info.ClusterClient.KubeClient.(*fake.Clientset)
+		require.True(t, ok)
+
+		fakeClient.PrependReactor("get", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("services is forbidden")
+		})
+
+		_, err := resolveLBTarget(t.Context(), attempt, topo, attempt.HelmReleaseNamePrefix+"-src", slogt.New(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "forbidden", "the API's own error is reported")
+
+		for _, action := range fakeClient.Actions() {
+			assert.NotEqual(t, "nodes", action.GetResource().Resource, "an API error must not fall back")
+		}
+	})
+
+	t.Run("no node port to fall back to", func(t *testing.T) {
+		info, attempt := lbFixtures(0, nil)
+		topo := topology{sshd: componentSide{info: info}}
+
+		_, err := resolveLBTarget(t.Context(), attempt, topo, attempt.HelmReleaseNamePrefix+"-src", slogt.New(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no node port allocated",
+			"a Service created without node ports has nothing to fall back to, and the error says so")
+	})
+}
+
+// TestInstallsLoadBalancer pins the check that decides whether Helm waits for a
+// release, against the values the strategies actually build, so the two sides
+// cannot drift apart and quietly bring the wait on the address back.
+func TestInstallsLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	info := &pvc.Info{Claim: &corev1.PersistentVolumeClaim{Namespace: "ns", Name: "pvc"}}
+	side := componentSide{info: info, mountPath: srcMountPath, readOnly: true}
+
+	assert.True(t, installsLoadBalancer(sshdReleaseValues(side, "ssh-ed25519 AAAA", "LoadBalancer")))
+	assert.False(t, installsLoadBalancer(sshdReleaseValues(side, "ssh-ed25519 AAAA", "NodePort")))
+	assert.False(t, installsLoadBalancer(sshdReleaseValues(side, "ssh-ed25519 AAAA", "ClusterIP")))
+	assert.False(t, installsLoadBalancer(map[string]any{sshdComponent: buildSshdHelmValues(side, "key")}),
+		"no service section means no load balancer")
+
+	disabled := sshdReleaseValues(side, "ssh-ed25519 AAAA", "LoadBalancer")
+	disabled[sshdComponent].(map[string]any)[keyEnabled] = false //nolint:forcetypeassert
+	assert.False(t, installsLoadBalancer(disabled),
+		"a release without sshd renders no Service, whatever the user's values say about its type")
+	assert.False(t, installsLoadBalancer(map[string]any{
+		"rsync": map[string]any{keyEnabled: true},
+		"sshd":  map[string]any{"service": map[string]any{"type": "LoadBalancer"}},
+	}), "a user value for the sshd Service type on a release without sshd changes nothing")
+	assert.False(t, installsLoadBalancer(map[string]any{}))
 }

--- a/internal/strategy/local.go
+++ b/internal/strategy/local.go
@@ -481,19 +481,22 @@ func buildRsyncCmdLocal(mig *migration.Migration) (string, error) {
 	return cmd, nil
 }
 
+// sshdLabelSelector selects the sshd pod of the named release.
+func sshdLabelSelector(release string) string {
+	return "app.kubernetes.io/component=sshd,app.kubernetes.io/instance=" + release
+}
+
 func getSshdPodForHelmRelease(
 	ctx context.Context,
 	pvcInfo *pvc.Info,
 	name string,
 	logger *slog.Logger,
 ) (*corev1.Pod, error) {
-	labelSelector := "app.kubernetes.io/component=sshd,app.kubernetes.io/instance=" + name
-
 	pod, err := k8s.WaitForPod(
 		ctx,
 		pvcInfo.ClusterClient.KubeClient,
 		pvcInfo.Claim.Namespace,
-		labelSelector,
+		sshdLabelSelector(name),
 		logger,
 	)
 	if err != nil {

--- a/internal/strategy/nodeport.go
+++ b/internal/strategy/nodeport.go
@@ -15,6 +15,12 @@ func (r *NodePort) Run(ctx context.Context, attempt *migration.Attempt, logger *
 	return runTwoReleaseStrategy(ctx, attempt, "NodePort", resolveNodePortTarget, logger)
 }
 
+// resolveNodePortTarget pairs the Service's node port with the address of the
+// node the sshd pod runs on, so the connection lands on the node that has the
+// pod rather than on one that has to forward it. Any node works when that one
+// has no usable address. With a host override the user has said where to
+// connect, so no node is looked up at all, which also spares the permission to
+// read nodes.
 func resolveNodePortTarget(
 	ctx context.Context,
 	attempt *migration.Attempt,
@@ -22,30 +28,42 @@ func resolveNodePortTarget(
 	sshdRelease string,
 	logger *slog.Logger,
 ) (sshTarget, error) {
-	sshdKubeClient := topo.sshd.info.ClusterClient.KubeClient
-	sshdNs := topo.sshd.info.Claim.Namespace
+	info := topo.sshd.info
+	cli := info.ClusterClient.KubeClient
 	svcName := sshdRelease + "-sshd"
 
 	nodePort, err := k8s.GetNodePort(
-		ctx, sshdKubeClient, sshdNs, svcName, attempt.Migration.Request.LoadBalancerTimeout,
+		ctx,
+		cli,
+		info.Claim.Namespace,
+		svcName,
+		attempt.Migration.Request.LoadBalancerTimeout,
 	)
 	if err != nil {
 		return sshTarget{}, fmt.Errorf("failed to get NodePort: %w", err)
 	}
 
-	sshdPod, err := getSshdPodForHelmRelease(ctx, topo.sshd.info, sshdRelease, logger)
+	if attempt.Migration.Request.DestHostOverride != "" {
+		logger.Info("🔗 Using the host override for the NodePort connection", "port", nodePort)
+
+		// The caller fills the host in from the override, so only the port is
+		// resolved here.
+		return sshTarget{port: nodePort}, nil
+	}
+
+	sshdPod, err := getSshdPodForHelmRelease(ctx, info, sshdRelease, logger)
 	if err != nil {
 		return sshTarget{}, fmt.Errorf("failed to get sshd pod: %w", err)
 	}
 
 	podNode := sshdPod.Spec.NodeName
 
-	nodeIP, err := k8s.GetNodeIP(ctx, sshdKubeClient, podNode)
+	nodeIP, err := k8s.GetNodeIP(ctx, cli, podNode)
 	if err != nil {
 		logger.Warn("🔶 Could not get sshd pod's node IP, falling back to another node",
 			"node", podNode, "error", err)
 
-		nodeIP, err = k8s.GetAnyNodeIP(ctx, sshdKubeClient)
+		nodeIP, err = k8s.GetAnyNodeIP(ctx, cli)
 		if err != nil {
 			return sshTarget{}, fmt.Errorf("failed to find usable node IP: %w", err)
 		}

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -18,6 +18,7 @@ import (
 	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/utkuozdemir/pv-migrate/internal/console"
 	"github.com/utkuozdemir/pv-migrate/internal/helm"
@@ -275,9 +276,7 @@ func installHelmChart(
 	install := action.NewInstall(helmActionConfig)
 	install.Namespace = pvcInfo.Claim.Namespace
 	install.ReleaseName = name
-	install.WaitStrategy = kube.LegacyStrategy
-
-	timeout, timeoutFlag := effectiveInstallTimeout(mig.Request, values)
+	timeout := mig.Request.HelmTimeout
 	install.Timeout = timeout
 
 	applyNonRootValues(values, mig.Request)
@@ -290,6 +289,19 @@ func installHelmChart(
 	vals, err := getMergedHelmValues(values, mig.Request, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get merged helm values: %w", err)
+	}
+
+	// Helm's wait blocks on a LoadBalancer Service until it has an address, and
+	// on a cluster without a load balancer controller that is forever. Such a
+	// release is not waited on by Helm at all. The sshd pod is waited for below
+	// instead, with the same budget, since nothing else would, and the strategy
+	// waits for the address itself, with its own budget and a fallback. Decided
+	// on the merged values, since the user's values can change the Service type.
+	install.WaitStrategy = kube.LegacyStrategy
+	waitForSshd := installsLoadBalancer(vals)
+
+	if waitForSshd {
+		install.WaitStrategy = kube.HookOnlyStrategy
 	}
 
 	// A long wait usually means the cluster already knows what is stuck, so at
@@ -305,11 +317,32 @@ func installHelmChart(
 		// headline of every stuck-resource failure.
 		if errors.Is(err, context.DeadlineExceeded) {
 			return fmt.Errorf(
-				"timed out after %s waiting for the release's resources to become ready (see %s): %w",
-				timeout, timeoutFlag, err)
+				"timed out after %s waiting for the release's resources to become ready (see --helm-timeout): %w",
+				timeout, err)
 		}
 
 		return fmt.Errorf("failed to install helm chart: %w", err)
+	}
+
+	if !waitForSshd {
+		return nil
+	}
+
+	return waitForSshdReady(ctx, pvcInfo.ClusterClient.KubeClient, sshdNamespace(vals), name, timeout, logger)
+}
+
+// waitForSshdReady stands in for Helm's wait on a release Helm was told not to
+// wait for, see installHelmChart. Ready rather than started, since that is what
+// Helm's wait would have established.
+func waitForSshdReady(
+	ctx context.Context,
+	cli kubernetes.Interface,
+	namespace, release string,
+	timeout time.Duration,
+	logger *slog.Logger,
+) error {
+	if _, err := k8s.WaitForPodReady(ctx, cli, namespace, sshdLabelSelector(release), timeout, logger); err != nil {
+		return fmt.Errorf("failed to wait for the sshd pod to become ready (see --helm-timeout): %w", err)
 	}
 
 	return nil
@@ -322,23 +355,13 @@ func canCreateNetworkPolicies(pvcInfo *pvc.Info) helm.CanCreateNetworkPoliciesFu
 	}
 }
 
-// effectiveInstallTimeout picks the install wait budget and names the flag it
-// came from. The load balancer timeout only applies when this release actually
-// waits for a load balancer, so a LoadBalancer-only flag cannot silently
-// lengthen every other strategy's install.
-func effectiveInstallTimeout(req *migration.Request, values map[string]any) (time.Duration, string) {
-	if installsLoadBalancer(values) && req.LoadBalancerTimeout > req.HelmTimeout {
-		return req.LoadBalancerTimeout, "--loadbalancer-timeout, which exceeds --helm-timeout"
-	}
-
-	return req.HelmTimeout, "--helm-timeout"
-}
-
-// installsLoadBalancer reports whether the values ask for a LoadBalancer
-// service, which the install wait then waits on.
+// installsLoadBalancer reports whether the values put an sshd with a
+// LoadBalancer Service into the release, whose address Helm's wait would
+// otherwise block on. A release without sshd renders no Service, whatever the
+// values say about its type.
 func installsLoadBalancer(values map[string]any) bool {
 	sshd, ok := values[sshdComponent].(map[string]any)
-	if !ok {
+	if !ok || sshd[keyEnabled] != true {
 		return false
 	}
 
@@ -348,6 +371,15 @@ func installsLoadBalancer(values map[string]any) bool {
 	}
 
 	return service["type"] == "LoadBalancer"
+}
+
+// sshdNamespace is where the release puts its sshd, which is not always the
+// release namespace: one release can span two namespaces.
+func sshdNamespace(values map[string]any) string {
+	sshd, _ := values[sshdComponent].(map[string]any)
+	namespace, _ := sshd[keyNamespace].(string)
+
+	return namespace
 }
 
 // peekAfter runs the peek once after the delay unless stopped first.

--- a/internal/strategy/topology.go
+++ b/internal/strategy/topology.go
@@ -201,10 +201,18 @@ func installSshd(
 	releaseName, publicKey, serviceType string,
 	logger *slog.Logger,
 ) error {
-	sshdVals := buildSshdHelmValues(topo.sshd, publicKey)
+	return installHelmChart(ctx, attempt, topo.sshd.info, releaseName,
+		sshdReleaseValues(topo.sshd, publicKey, serviceType), logger)
+}
+
+// sshdReleaseValues builds the values of an sshd release whose Service has the
+// given type. The type is what decides whether Helm waits for the release, see
+// installsLoadBalancer.
+func sshdReleaseValues(side componentSide, publicKey, serviceType string) map[string]any {
+	sshdVals := buildSshdHelmValues(side, publicKey)
 	sshdVals["service"] = map[string]any{"type": serviceType}
 
-	return installHelmChart(ctx, attempt, topo.sshd.info, releaseName, map[string]any{sshdComponent: sshdVals}, logger)
+	return map[string]any{sshdComponent: sshdVals}
 }
 
 func installRsyncJob(


### PR DESCRIPTION
On a cluster without a load balancer controller, or with one that does not serve the Service, the loadbalancer strategy waited for an address that never came and then failed. With the default strategy order that was the end of the run, because the nodeport strategy is not in it. The user had to know about that strategy to get a migration across clusters.

A LoadBalancer Service carries a node port as well, so the fallback is free. The loadbalancer strategy now waits for the address up to the load balancer timeout. When none arrives, it connects to that node port on the node the sshd pod runs on, the same way the nodeport strategy does. A warning says why, and names the timeout to raise when the controller is merely slow. Only a missing address falls back: an error from the API is reported as it is, and a Service created without node ports is reported as such.

For this to work, Helm is no longer asked to wait for a release that puts an sshd with a LoadBalancer Service into the cluster, since its wait blocks on the address for the whole install timeout. Such a release has no readiness gate then, so the install waits for the sshd pod to become ready itself, within the install timeout and with the same look at what the cluster reports halfway through, and the strategy then waits for the address with the load balancer timeout. Whether a release is one of those is decided on the final values, so a Service type set through the chart values counts too. Two things follow for this strategy: the sshd pod's default budget is the install timeout, one minute, where it used to borrow the longer load balancer timeout, and the two waits run one after the other rather than sharing a budget.

Additionally, a node port set through the chart values is now applied to a LoadBalancer Service as well, not only to a NodePort one. When a host override is given, neither the fallback nor the nodeport strategy looks up a node address anymore, so an account that cannot read nodes can use them with a hint.

An integration test covers the fallback with a load balancer class that no controller implements.
