### PR TITLE
fix: name every chart resource after the release, without overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,9 +139,10 @@ Some specifics that surprise people:
 ## The embedded chart
 
 The chart lives in `internal/helm/pv-migrate` and is compiled into the binary, so the released CLI and the chart it installs always match.
-Two things follow:
+Therefore:
 
 - The chart is not published for standalone use and is not versioned independently. Its in-repo version is a placeholder that the CLI overwrites with its own at load time.
+- Every resource name derives from the release name, which the CLI sets, and the CLI looks its resources up by names it derives the same way. The chart therefore has no name overrides: a value that renamed the objects would do so without the CLI knowing, and every lookup would wait for a name that does not exist.
 - Changing a template changes the binary, so chart edits are code changes and need the Go tests, not only `helm lint`.
 - The Job scripts decide the container's exit code, and the client reads it back and attaches the data mover's own documented meaning for it.
   So the retry loops capture the code rather than collapsing it, a condition the script decides to treat as a success announces itself with a line the client scans for, and the interpretation tables live next to the command builders they describe.

--- a/internal/helm/pv-migrate/README.md
+++ b/internal/helm/pv-migrate/README.md
@@ -20,8 +20,6 @@ The helm chart of pv-migrate
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| fullnameOverride | string | `""` | String to fully override the fullname template with a string |
-| nameOverride | string | `""` | String to partially override the fullname template with a string (will prepend the release name) |
 | rclone.affinity | object | `{}` | Rclone pod affinity |
 | rclone.backoffLimit | int | `0` |  |
 | rclone.command | string | `""` | Full Rclone command |

--- a/internal/helm/pv-migrate/templates/_helpers.tpl
+++ b/internal/helm/pv-migrate/templates/_helpers.tpl
@@ -1,18 +1,11 @@
-{{- define "pv-migrate.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
+{{- /*
+The tool looks its resources up by name, and the names it uses are derived from
+the release name, which it always sets. So the chart names everything from the
+release name and nothing else: no name overrides, since an override would rename
+the objects without the tool knowing.
+*/ -}}
 {{- define "pv-migrate.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- .Release.Name }}
 {{- end }}
 
 {{- define "pv-migrate.chart" -}}
@@ -29,7 +22,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{- define "pv-migrate.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "pv-migrate.name" . }}
+app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/internal/helm/pv-migrate/values.yaml
+++ b/internal/helm/pv-migrate/values.yaml
@@ -1,8 +1,3 @@
-# -- String to partially override the fullname template with a string (will prepend the release name)
-nameOverride: ""
-# -- String to fully override the fullname template with a string
-fullnameOverride: ""
-
 sshd:
   # -- Enable SSHD server deployment
   enabled: false

--- a/internal/helm/render_test.go
+++ b/internal/helm/render_test.go
@@ -229,3 +229,44 @@ func TestNodePortPinAppliesToLoadBalancerService(t *testing.T) {
 
 	assert.Contains(t, rendered["pv-migrate/templates/sshd/service.yaml"], "nodePort: 30555")
 }
+
+// TestResourceNamesDeriveFromTheReleaseName pins the contract the tool's lookups
+// rely on: the Service and the Jobs are named after the release, and nothing in
+// the values can rename them. A leftover name override in the values must be
+// ignored rather than honored, since the tool would not know about it.
+func TestResourceNamesDeriveFromTheReleaseName(t *testing.T) {
+	t.Parallel()
+
+	// The two override keys are the point of the test, not setup: with them, the
+	// old helpers renamed everything, and the assertions below would fail.
+	rendered := render(t, map[string]any{
+		"fullnameOverride": "renamed",
+		"nameOverride":     "renamed",
+		"sshd": map[string]any{
+			"enabled":   true,
+			"namespace": "default",
+			"publicKey": "ssh-ed25519 AAAA",
+			"pvcMounts": []any{map[string]any{"name": "pvc", "mountPath": "/source"}},
+		},
+		"rsync": map[string]any{
+			"enabled":   true,
+			"namespace": "default",
+			"command":   "rsync -a '/source/' '/dest/'",
+			"pvcMounts": []any{map[string]any{"name": "pvc", "mountPath": "/dest"}},
+		},
+		"rclone": map[string]any{
+			"enabled":   true,
+			"namespace": "default",
+			"command":   "rclone sync '/data' 'remote:b/'",
+			"pvcMounts": []any{map[string]any{"name": "pvc", "mountPath": "/data"}},
+		},
+	})
+
+	assert.Contains(t, rendered["pv-migrate/templates/sshd/service.yaml"], "name: pv-migrate-test-sshd")
+	assert.Contains(t, rendered["pv-migrate/templates/rsync/job.yaml"], "name: pv-migrate-test-rsync")
+	assert.Contains(t, rendered["pv-migrate/templates/rclone/job.yaml"], "name: pv-migrate-test-rclone")
+
+	for file, content := range rendered {
+		assert.NotContains(t, content, "renamed", "%s honors a name override the tool does not know about", file)
+	}
+}


### PR DESCRIPTION
The chart named its resources through a template that honored two override values, while the tool looked them up by names derived from the release name it sets: the sshd Service, the rsync Job and the rclone Job. With either override set through the chart values, the objects got other names, unless the value happened to be part of the release name already, and every lookup then waited for a name that did not exist, until the timeout.

The chart is embedded and not published for standalone use, and the tool always sets the release name, so the overrides had no use the tool supported. They are removed, and every resource is named after the release and nothing else. A leftover override in the values is ignored rather than honored, which a test pins together with the names the tool relies on.

Closes #486.
